### PR TITLE
fix(menu): do not show routes without label on main drawer

### DIFF
--- a/src/components/main-drawer.js
+++ b/src/components/main-drawer.js
@@ -38,7 +38,7 @@ const styles = theme => ({
 
 const Menu = ({ onClick, currentPathname, links, classes, t }) => (
   <List>
-    {links.map(({ to, label, collapsedItems }) => {
+    {links.filter(({ label }) => label).map(({ to, label, collapsedItems }) => {
       // FIXME: we should try to use mui's way, for some reason
       // it didn't work for me
       const isSelected = currentPathname === to


### PR DESCRIPTION
### Steps to test
- Look at the elements in drawer menu on the left, you should be able to see and click only the routes that on `src/routes/index.js` have `drawerLabel`.