### PR TITLE
refactor(i18n): change all instances of translate to withNamespaces

### DIFF
--- a/services/frontend/src/components/bottom-navbar.js
+++ b/services/frontend/src/components/bottom-navbar.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import { withStyles } from '@material-ui/core/styles'
 import BottomNavigation from '@material-ui/core/BottomNavigation'
 import BottomNavigationAction from '@material-ui/core/BottomNavigationAction'
@@ -68,5 +68,5 @@ SimpleBottomNavigation.propTypes = {
 }
 
 export default withStyles(styles)(
-  translate('translations')(SimpleBottomNavigation)
+  withNamespaces('translations')(SimpleBottomNavigation)
 )

--- a/services/frontend/src/components/input-autocomplete.js
+++ b/services/frontend/src/components/input-autocomplete.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import { Redux } from 'redux-render'
 import Highlight from 'react-highlighter'
 import Autosuggest from 'react-autosuggest'
@@ -198,4 +198,6 @@ InputAutocomplete.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default withStyles(style)(translate('translations')(InputAutocomplete))
+export default withStyles(style)(
+  withNamespaces('translations')(InputAutocomplete)
+)

--- a/services/frontend/src/components/main-drawer.js
+++ b/services/frontend/src/components/main-drawer.js
@@ -8,7 +8,7 @@ import { withStyles } from '@material-ui/core/styles'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import { Link } from '@reach/router'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 
 import routes from 'routes'
 
@@ -173,5 +173,5 @@ MainDrawer.propTypes = {
 }
 
 export default withStyles(styles, { withTheme: true })(
-  translate('translations')(MainDrawer)
+  withNamespaces('translations')(MainDrawer)
 )

--- a/services/frontend/src/routes/account/index.js
+++ b/services/frontend/src/routes/account/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import PropTypes from 'prop-types'
 import { Redux } from 'redux-render'
 import Component from '@reach/component-component'
@@ -28,4 +28,4 @@ Account.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default translate('translations')(Account)
+export default withNamespaces('translations')(Account)

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Redux } from 'redux-render'
 import Grid from '@material-ui/core/Grid'
 import { withStyles } from '@material-ui/core/styles'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import Component from '@reach/component-component'
 
 import BlockProducerCard from 'components/block-producer-card'
@@ -94,6 +94,6 @@ AllBps.propTypes = {
   // t: PropTypes.func.isRequired
 }
 
-export default withStyles(style)(translate('translations')(AllBps))
+export default withStyles(style)(withNamespaces('translations')(AllBps))
 
 export const blockProducersDrawer = [FilterBox]

--- a/services/frontend/src/routes/login/index.js
+++ b/services/frontend/src/routes/login/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import * as yup from 'yup'
 import { Redux } from 'redux-render'
 import { Formik, Form } from 'formik'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import PropTypes from 'prop-types'
 import TextField from 'components/textField'
 import Button from 'components/button'
@@ -62,4 +62,4 @@ Login.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default translate('translations')(Login)
+export default withNamespaces('translations')(Login)

--- a/services/frontend/src/routes/not-found/index.js
+++ b/services/frontend/src/routes/not-found/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import PropTypes from 'prop-types'
 
 const NotFound = ({ t }) => <h1>{t('notFound')}</h1>
@@ -8,4 +8,4 @@ NotFound.propTypes = {
   t: PropTypes.func.isRequired
 }
 
-export default translate('translations')(NotFound)
+export default withNamespaces('translations')(NotFound)

--- a/services/frontend/src/routes/settings/index.js
+++ b/services/frontend/src/routes/settings/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Redux } from 'redux-render'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
-import { translate } from 'react-i18next'
+import { withNamespaces } from 'react-i18next'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
@@ -97,4 +97,4 @@ Settings.propTypes = {
   i18n: PropTypes.object.isRequired
 }
 
-export default withStyles(styles)(translate('translations')(Settings))
+export default withStyles(styles)(withNamespaces('translations')(Settings))


### PR DESCRIPTION
### Steps to test
- Look on `src` folder for any `translate` uses from `react-i18next`, there should be none at all.