### PR TITLE
style(BP Cards) apply visual tweaking to block producer cards

### DIFF
--- a/services/frontend/src/components/block-producer-card.js
+++ b/services/frontend/src/components/block-producer-card.js
@@ -8,15 +8,20 @@ import Avatar from '@material-ui/core/Avatar'
 import IconButton from '@material-ui/core/IconButton'
 import AddIcon from '@material-ui/icons/Add'
 import RemoveIcon from '@material-ui/icons/Remove'
-import ShareIcon from '@material-ui/icons/Share'
+import InfoIcon from '@material-ui/icons/Info'
 
 import comparisonParameters from 'config/comparison-parameters'
 import BlockProducerRadar from 'components/block-producer-radar'
 
 const styles = theme => ({
   card: {},
+  title: {
+    textDecoration: 'none',
+    color: '#ffffff'
+  },
   actions: {
-    display: 'flex'
+    display: 'flex',
+    justifyContent: 'space-between'
   },
   radar: {
     background: theme.palette.primary.dark,
@@ -42,7 +47,15 @@ const BlockProducerCard = ({
           BP
         </Avatar>
       }
-      title={blockProducer.org.candidate_name}
+      title={
+        <a
+          target='_blank'
+          href={blockProducer.org.website}
+          className={classes.title}
+        >
+          {blockProducer.org.candidate_name}
+        </a>
+      }
       subheader={blockProducer.producer_account_name}
     />
     <div className={classes.radar}>
@@ -63,8 +76,12 @@ const BlockProducerCard = ({
       >
         {isSelected ? <RemoveIcon /> : <AddIcon />}
       </IconButton>
-      <IconButton aria-label='Share'>
-        <ShareIcon />
+      <IconButton
+        aria-label='Info'
+        href={blockProducer.org.website}
+        target='_blank'
+      >
+        <InfoIcon />
       </IconButton>
     </CardActions>
   </Card>

--- a/services/frontend/src/components/block-producer-radar.js
+++ b/services/frontend/src/components/block-producer-radar.js
@@ -8,6 +8,7 @@ const BlockProducerRadar = ({ bpData, ...props }) => (
       ...bpData
     })}
     options={{
+      legend: { display: false },
       chartArea: {
         backgroundColor: '#484656',
         strokeColor: '#b1afad',


### PR DESCRIPTION
This PR includes changes `/block-producers` url.
Ticket #84 

### Changes:
- [x] Remove graph legend on the BP card.
- [x]   Remove share icon.
- [x] Add info button. It should be a link to the BP page.
- [x]   The card title (BP name) should be a link to the BP page.

### Old look
<img width="402" alt="screen shot 2018-11-20 at 11 41 15 pm" src="https://user-images.githubusercontent.com/8497609/48821259-2461ef80-ed1e-11e8-97ca-50bc9e2ecd91.png">

### Current look
<img width="462" alt="screen shot 2018-11-20 at 11 41 52 pm" src="https://user-images.githubusercontent.com/8497609/48821275-2f1c8480-ed1e-11e8-98d7-6d75807d5124.png">
