### PR TITLE
fix(webapp): adjust bottom padding on radar chart

### DIFF
--- a/services/frontend/src/components/block-producer-radar.js
+++ b/services/frontend/src/components/block-producer-radar.js
@@ -9,6 +9,11 @@ const BlockProducerRadar = ({ bpData, ...props }) => (
     })}
     options={{
       legend: { display: false },
+      layout: {
+        padding: {
+          bottom: 10
+        }
+      },
       chartArea: {
         backgroundColor: '#484656',
         strokeColor: '#b1afad',


### PR DESCRIPTION
### Steps to reproduce

1. Open up the main page and go to `Block Producers`.
1. Radars should look complete with no cutoff anywhere in the chart.
1. Add radars to the compare tool.
1. All radars should look complete with no cutoffs.