### PR TITLE
style(radar) improvements to visual tweaks to radar

### DIFF
--- a/services/frontend/src/components/block-producer-card.js
+++ b/services/frontend/src/components/block-producer-card.js
@@ -65,6 +65,7 @@ const BlockProducerCard = ({
     />
     <div className={classes.radar}>
       <BlockProducerRadar
+        height={200}
         bpData={{
           labels: comparisonParameters,
           datasets: [{ ...blockProducer.data }]

--- a/services/frontend/src/components/block-producer-radar.js
+++ b/services/frontend/src/components/block-producer-radar.js
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Radar } from 'react-chartjs-2'
 
-const BlockProducerRadar = ({ bpData, ...props }) => (
+const BlockProducerRadar = ({ bpData, height, ...props }) => (
   <Radar
+    height={height}
     data={() => ({
       ...bpData
     })}
@@ -20,17 +21,23 @@ const BlockProducerRadar = ({ bpData, ...props }) => (
         lineWidth: 4
       },
       scale: {
-        ticks: { display: false },
+        ticks: {
+          display: false,
+          min: 0,
+          max: 10,
+          stepSize: 2
+        },
         gridLines: { color: '#6e6b81', lineWidth: 4, circular: true },
         angleLines: { color: '#6e6b81', lineWidth: 4 },
-        pointLabels: { fontColor: 'white' }
+        pointLabels: { fontColor: 'white', fontSize: 14 }
       }
     }}
   />
 )
 
 BlockProducerRadar.propTypes = {
-  bpData: PropTypes.object
+  bpData: PropTypes.object,
+  height: PropTypes.number
 }
 
 export default BlockProducerRadar

--- a/services/frontend/src/config/radar.js
+++ b/services/frontend/src/config/radar.js
@@ -19,19 +19,33 @@ Chart.pluginService.register({
       ctx.restore()
     }
   },
-  afterDraw: chart => {
+  beforeDatasetsDraw: chart => {
     const { ctx, scale, config } = chart
     const { xCenter, yCenter, drawingArea: radius } = scale
+
     const strokeColor = get(config, 'options.chartArea.strokeColor', false)
     const lineWidth = get(config, 'options.chartArea.lineWidth', 0)
+    const centerPointColor = get(config, 'options.scale.gridLines.color', false)
 
-    if (strokeColor && lineWidth) {
-      ctx.beginPath()
-      ctx.arc(xCenter, yCenter, radius, 0, Math.PI * 2)
-      ctx.strokeStyle = strokeColor
-      ctx.lineWidth = lineWidth
-      ctx.stroke()
-      ctx.restore()
-    }
+    /** start render dot in the center **/
+    ctx.save()
+    ctx.arc(xCenter, yCenter, radius / 16, 0, Math.PI * 2)
+
+    if (centerPointColor) ctx.fillStyle = centerPointColor
+
+    ctx.fill()
+    /** end to render dot **/
+
+    /** start render external ring **/
+    ctx.beginPath()
+    ctx.arc(xCenter, yCenter, radius, 0, Math.PI * 2)
+
+    if (strokeColor) ctx.strokeStyle = strokeColor
+    if (lineWidth) ctx.lineWidth = lineWidth
+
+    ctx.stroke()
+    /** end render external ring **/
+
+    ctx.restore()
   }
 })


### PR DESCRIPTION
This affect `/block-producers` path.

Adjust radar's settings in order to have the same numbers(5) of lines by radar, chage the font size for point labels and increment the height of the cards in order to take advantage more the inner space.

### Before:
<img width="526" alt="screen shot 2018-11-24 at 7 37 37 am" src="https://user-images.githubusercontent.com/8497609/48968929-f4377c80-efbb-11e8-88bf-af7b8e7c4e65.png">
<img width="458" alt="screen shot 2018-11-24 at 7 38 11 am" src="https://user-images.githubusercontent.com/8497609/48968930-f4377c80-efbb-11e8-972e-f49d6ebac475.png">

### After:
<img width="541" alt="screen shot 2018-11-24 at 7 17 06 am" src="https://user-images.githubusercontent.com/8497609/48968927-f4377c80-efbb-11e8-8ec9-3e89bc30ab86.png">
<img width="462" alt="screen shot 2018-11-24 at 7 17 17 am" src="https://user-images.githubusercontent.com/8497609/48968928-f4377c80-efbb-11e8-864b-026fe777f559.png">
