### PR TITLE
fix(webapp): adjust sidebar to alpha release version

### DIFF
--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -23,6 +23,7 @@
     "@rematch/persist": "^1.0.2",
     "apollo-boost": "^0.1.16",
     "chart.js": "^2.7.2",
+    "classnames": "^2.2.6",
     "env-cmd": "^8.0.2",
     "filter-objects": "^2.1.1",
     "graphql": "^14.0.2",

--- a/services/frontend/src/components/app-bar.js
+++ b/services/frontend/src/components/app-bar.js
@@ -31,10 +31,7 @@ const styles = theme => ({
   },
   menuButton: {
     marginLeft: -18,
-    marginRight: 10,
-    [theme.breakpoints.up('md')]: {
-      display: 'none'
-    }
+    marginRight: 10
   },
   search: {
     position: 'relative',

--- a/services/frontend/src/components/layout.js
+++ b/services/frontend/src/components/layout.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Hidden from '@material-ui/core/Hidden'
+import classnames from 'classnames'
 import MainTopBar from 'components/app-bar'
 import MainDrawer from 'components/main-drawer'
 import MainFooter from 'components/main-footer'
@@ -16,10 +17,12 @@ const styles = theme => ({
     display: 'flex',
     width: '100%'
   },
-  navIconHide: {
-    [theme.breakpoints.up('md')]: {
-      display: 'none'
-    }
+  desktopDrawer: {
+    width: 240,
+    transition: 'width 225ms cubic-bezier(0, 0, 0.2, 1) 0ms'
+  },
+  desktopDrawerHidden: {
+    width: 0
   },
   toolbar: theme.mixins.toolbar,
   content: {
@@ -35,11 +38,10 @@ const styles = theme => ({
 
 class Layout extends Component {
   state = {
-    mobileNavOpen: false
+    isNavOpen: false
   }
 
-  handleDrawerToggle = () =>
-    this.setState({ mobileNavOpen: !this.state.mobileNavOpen })
+  handleDrawerToggle = () => this.setState({ isNavOpen: !this.state.isNavOpen })
 
   render () {
     const { classes, children } = this.props
@@ -49,12 +51,21 @@ class Layout extends Component {
         <Hidden mdUp>
           <MainDrawer
             variant='mobile'
-            open={this.state.mobileNavOpen}
+            open={this.state.isNavOpen}
             onClose={this.handleDrawerToggle}
           />
         </Hidden>
-        <Hidden smDown implementation='css'>
-          <MainDrawer />
+        <Hidden
+          className={classnames(classes.desktopDrawer, {
+            [classes.desktopDrawerHidden]: !this.state.isNavOpen
+          })}
+          smDown
+          implementation='css'
+        >
+          <MainDrawer
+            open={this.state.isNavOpen}
+            onClose={this.handleDrawerToggle}
+          />
         </Hidden>
         <main className={classes.content}>
           <div className={classes.toolbar} />

--- a/services/frontend/src/components/main-drawer.js
+++ b/services/frontend/src/components/main-drawer.js
@@ -132,8 +132,8 @@ const MainDrawer = ({
         )}
         {variant === 'desktop' && (
           <Drawer
-            variant='permanent'
-            open
+            variant='persistent'
+            open={open}
             classes={{
               paper: classes.drawerPaper
             }}

--- a/services/frontend/src/language/en.json
+++ b/services/frontend/src/language/en.json
@@ -1,6 +1,7 @@
 {
   "translations": {
     "compareToolTitle": "Compare Tool",
+    "compareToolToggle": "Compare",
     "compareToolCollapsedSwitch": "Collapse Graphs",
 
     "loginUsername": "Username",

--- a/services/frontend/src/language/es.json
+++ b/services/frontend/src/language/es.json
@@ -1,6 +1,7 @@
 {
   "translations": {
     "compareToolTitle": "Herramienta de comparación",
+    "compareToolToggle": "Comparar",
     "compareToolCollapsedSwitch": "Colapsar Gráficos",
 
     "loginUsername": "Nombre de usuario",

--- a/services/frontend/src/models/blockProducers.js
+++ b/services/frontend/src/models/blockProducers.js
@@ -8,12 +8,19 @@ const initialState = {
   list: [],
   filtered: [],
   selected: [],
-  currentBP: []
+  currentBP: [],
+  compareTool: true
 }
 
 const blockProducers = {
   state: initialState,
   reducers: {
+    toggleCompareTool (state) {
+      return {
+        ...state,
+        compareTool: !state.compareTool
+      }
+    },
     setBPs (state, list) {
       // Whenever we get a new list, clear filters
       return {

--- a/services/frontend/src/routes/block-producers/compare-tool-toggle.js
+++ b/services/frontend/src/routes/block-producers/compare-tool-toggle.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import { Redux } from 'redux-render'
+import { withNamespaces } from 'react-i18next'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+import VisibilityIcon from '@material-ui/icons/Visibility'
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff'
+
+const style = theme => ({
+  nested: {
+    // paddingLeft: theme.spacing.unit * 2,
+    color: 'white'
+  },
+  listItem: {
+    display: 'block'
+  }
+})
+
+const CompareToolToggle = ({ classes, t, ...props }) => (
+  <Redux
+    selector={state => ({
+      compareTool: state.blockProducers.compareTool,
+      selectedCount: state.blockProducers.selected.length
+    })}
+  >
+    {({ compareTool, selectedCount }, dispatch) => (
+      <List className={classes.nested}>
+        <ListItem
+          className={classes.listItem}
+          button
+          onClick={() => dispatch.blockProducers.toggleCompareTool()}
+        >
+          <ListItemText
+            primary={`${t('compareToolToggle')}(${selectedCount})`}
+          />
+          <ListItemSecondaryAction>
+            {compareTool ? <VisibilityIcon /> : <VisibilityOffIcon />}
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
+    )}
+  </Redux>
+)
+
+CompareToolToggle.propTypes = {
+  classes: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired
+}
+
+export default withStyles(style)(
+  withNamespaces('translations')(CompareToolToggle)
+)

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -4,18 +4,35 @@ import { Redux } from 'redux-render'
 import Grid from '@material-ui/core/Grid'
 import { withStyles } from '@material-ui/core/styles'
 import { withNamespaces } from 'react-i18next'
+import classNames from 'classnames'
 import Component from '@reach/component-component'
 
 import BlockProducerCard from 'components/block-producer-card'
 import CompareTool from 'components/compare-tool'
-import FilterBox from './filter-box'
+// import FilterBox from './filter-box'
+import CompareToolToggle from './compare-tool-toggle'
 
 const style = theme => ({
   wrapper: {
     padding: theme.spacing.unit * 3
   },
   compareTool: {
-    minHeight: 340
+    minHeight: 340,
+    transform: 'scaleY(1)',
+    transformOrigin: 'top',
+    opacity: 1,
+    transition: [
+      'opacity 0.25s ease',
+      'height 0.25s ease',
+      'transform 0.25s ease',
+      'min-height 0.25s ease'
+    ]
+  },
+  hidden: {
+    opacity: 0,
+    transform: 'scaleY(0)',
+    minHeight: 0,
+    height: 0
   }
 })
 
@@ -25,10 +42,20 @@ const AllBps = ({ classes, ...props }) => (
       fullBPState: state.blockProducers,
       blockProducers: state.blockProducers.list,
       selectedBPs: state.blockProducers.selected,
-      filtered: state.blockProducers.filtered
+      filtered: state.blockProducers.filtered,
+      compareToolVisible: state.blockProducers.compareTool
     })}
   >
-    {({ fullBPState, selectedBPs, blockProducers, filtered }, dispatch) => {
+    {(
+      {
+        fullBPState,
+        selectedBPs,
+        blockProducers,
+        filtered,
+        compareToolVisible
+      },
+      dispatch
+    ) => {
       const bpList = filtered.length ? filtered : blockProducers
       return (
         <Component componentDidMount={() => dispatch.blockProducers.getBPs()}>
@@ -38,7 +65,9 @@ const AllBps = ({ classes, ...props }) => (
                 removeBP={producerAccountName => () => {
                   dispatch.blockProducers.removeSelected(producerAccountName)
                 }}
-                className={classes.compareTool}
+                className={classNames(classes.compareTool, {
+                  [classes.hidden]: !compareToolVisible
+                })}
                 bpList={blockProducers}
                 selected={selectedBPs}
               />
@@ -96,4 +125,7 @@ AllBps.propTypes = {
 
 export default withStyles(style)(withNamespaces('translations')(AllBps))
 
-export const blockProducersDrawer = [FilterBox]
+export const blockProducersDrawer = [
+  CompareToolToggle
+  // FilterBox
+]


### PR DESCRIPTION
### Steps to test
1. Open up the homepage.
1. Side menu should be hidden away.
1. Clicking to block producers, should appear an option to hide/show the compare tool.
1. Clicking the hide/show compare tool switch, should toggle visibility of compare tool.
1. Filter sliders should not be visible, nor be in the DOM at all.