### PR TITLE
feat(webapp): consume block producers from graphql endpoint

### DIFF
--- a/services/demux/src/services/update-bps/index.js
+++ b/services/demux/src/services/update-bps/index.js
@@ -25,8 +25,8 @@ const getBlockProducersData = async () => {
   const producersData = cleanProducersList.map(bpData => {
     return {
       owner: bpData.owner,
-      system: JSON.stringify(bpData),
-      bpjson: producersBPJSON[bpData.owner][0].json
+      system: bpData,
+      bpjson: JSON.parse(producersBPJSON[bpData.owner][0].json)
     };
   });
   return producersData;
@@ -42,8 +42,8 @@ const updateBlockProducersData = async () => {
     console.log(`try save ${bp.owner}`);
     const bpData = {
       owner: bp.owner,
-      system: JSON.stringify(bp.system),
-      bpjson: JSON.stringify(bp.bpjson)
+      system: bp.system,
+      bpjson: bp.bpjson
     };
     try {
       const result = await db.producers.save(bpData);

--- a/services/frontend/.env
+++ b/services/frontend/.env
@@ -1,2 +1,3 @@
 NODE_PATH=src
 REACT_APP_API_URL=https://api.eosio.cr
+GRAPHQL_URL=http://localhost:8088/v1alpha1/graphql

--- a/services/frontend/src/components/block-producer-card.js
+++ b/services/frontend/src/components/block-producer-card.js
@@ -54,14 +54,14 @@ const BlockProducerCard = ({
       title={
         <a
           target='_blank'
-          href={blockProducer.org.website}
+          href={blockProducer.bpjson.org.website}
           className={classes.title}
           rel='noopener noreferrer'
         >
-          {blockProducer.org.candidate_name}
+          {blockProducer.bpjson.org.candidate_name}
         </a>
       }
-      subheader={blockProducer.producer_account_name}
+      subheader={blockProducer.bpjson.producer_account_name}
     />
     <div className={classes.radar}>
       <BlockProducerRadar
@@ -77,20 +77,22 @@ const BlockProducerCard = ({
         aria-label='Add to comparison'
         onClick={toggleSelection(
           !isSelected,
-          blockProducer.producer_account_name
+          blockProducer.bpjson.producer_account_name
         )}
       >
         {isSelected ? <RemoveIcon /> : <AddIcon />}
       </IconButton>
       <IconButton
         aria-label='Info'
-        href={blockProducer.org.website}
+        href={blockProducer.bpjson.org.website}
         target='_blank'
         rel='noopener noreferrer'
       >
         <InfoIcon />
       </IconButton>
-      <Link to={`/block-producers/${blockProducer.producer_account_name}`}>
+      <Link
+        to={`/block-producers/${blockProducer.bpjson.producer_account_name}`}
+      >
         <IconButton>
           <AccountBox />
         </IconButton>

--- a/services/frontend/src/components/compare-tool/compare-graph-view.js
+++ b/services/frontend/src/components/compare-tool/compare-graph-view.js
@@ -63,7 +63,7 @@ const CompareGraphView = ({
       {selected.map(bp => (
         <div
           className={classes.bpItem}
-          key={`bp-list-name-${bp.producer_account_name}`}
+          key={`bp-list-name-${bp.bpjson.producer_account_name}`}
         >
           <div className={classes.bpNameWrapper}>
             <Avatar
@@ -72,11 +72,11 @@ const CompareGraphView = ({
               style={{ backgroundColor: bp.data.pointBackgroundColor }}
             />
             <Typography className={classes.bpName} component='span'>
-              {bp.producer_account_name}
+              {bp.bpjson.producer_account_name}
             </Typography>
           </div>
           <IconButton
-            onClick={removeBP(bp.producer_account_name)}
+            onClick={removeBP(bp.bpjson.producer_account_name)}
             aria-label='Remove block producer'
           >
             <CloseIcon />

--- a/services/frontend/src/components/compare-tool/compare-slider-view.js
+++ b/services/frontend/src/components/compare-tool/compare-slider-view.js
@@ -38,7 +38,7 @@ const CompareSliderView = ({ classes, selected, className, t, ...props }) => (
     <div className={classes.slider}>
       {selected.map(bp => (
         <div
-          key={`slider-card-${bp.producer_account_name}`}
+          key={`slider-card-${bp.bpjson.producer_account_name}`}
           className={classes.sliderCard}
         >
           <BlockProducerRadar
@@ -48,7 +48,7 @@ const CompareSliderView = ({ classes, selected, className, t, ...props }) => (
             }}
           />
           <Typography variant='subheading' className={classes.bpName}>
-            {bp.producer_account_name}
+            {bp.bpjson.producer_account_name}
           </Typography>
         </div>
       ))}

--- a/services/frontend/src/components/compare-tool/index.js
+++ b/services/frontend/src/components/compare-tool/index.js
@@ -43,7 +43,7 @@ const CompareTool = ({
     {({ setState, state }) => {
       const selectedBlockProducers = selected.map(bpName =>
         bpList.find(
-          ({ producer_account_name: producerAccountName }) =>
+          ({ bpjson: { producer_account_name: producerAccountName } }) =>
             bpName === producerAccountName
         )
       )

--- a/services/frontend/src/models/blockProducers.js
+++ b/services/frontend/src/models/blockProducers.js
@@ -1,6 +1,6 @@
 import filterObjects from 'filter-objects'
 import uniq from 'lodash.uniq'
-import { findBPs } from 'services/bps'
+import { getAllBPs } from 'services/bps'
 import getBPRadarData from 'utils/getBPRadarData'
 
 const initialState = {
@@ -58,11 +58,14 @@ const blockProducers = {
   },
   effects: {
     async getBPs () {
-      const blockProducers = await findBPs()
+      const blockProducers = await getAllBPs()
       this.setBPs(
         blockProducers.map(blockProducer => ({
           ...blockProducer,
-          data: getBPRadarData(blockProducer)
+          data: getBPRadarData({
+            ...blockProducer.bpjson,
+            parameters: blockProducer.system.parameters
+          })
         }))
       )
     },

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -84,12 +84,12 @@ const AllBps = ({ classes, ...props }) => (
                     sm={6}
                     md={4}
                     key={`${
-                      blockProducer.producer_account_name
+                      blockProducer.bpjson.producer_account_name
                     }-main-block-card`}
                   >
                     <BlockProducerCard
                       isSelected={selectedBPs.includes(
-                        blockProducer.producer_account_name
+                        blockProducer.bpjson.producer_account_name
                       )}
                       toggleSelection={(
                         isAdding,

--- a/services/frontend/src/services/bps.js
+++ b/services/frontend/src/services/bps.js
@@ -20,9 +20,8 @@ export const getAllBPs = async () => {
   })
   return producers.map(producer => ({
     ...producer,
-    bpjson: JSON.parse(producer.bpjson),
     system: {
-      ...JSON.parse(producer.system),
+      ...producer.system,
       parameters: {
         infrastructure: getRandomParameter(),
         tooling: getRandomParameter(),

--- a/services/frontend/src/services/bps.js
+++ b/services/frontend/src/services/bps.js
@@ -1,5 +1,41 @@
 import mockedBPs from 'mock/bps'
+import client from 'services/graphql'
+import gql from 'graphql-tag'
+
+const getRandomParameter = (max = 10) => Math.floor(Math.random() * max)
+
+export const getAllBPs = async () => {
+  const {
+    data: { producers }
+  } = await client.query({
+    query: gql`
+      query AllBPs {
+        producers {
+          bpjson
+          owner
+          system
+        }
+      }
+    `
+  })
+  return producers.map(producer => ({
+    ...producer,
+    bpjson: JSON.parse(producer.bpjson),
+    system: {
+      ...JSON.parse(producer.system),
+      parameters: {
+        infrastructure: getRandomParameter(),
+        tooling: getRandomParameter(),
+        community: getRandomParameter(),
+        transparency: getRandomParameter(),
+        testnets: getRandomParameter()
+      }
+    }
+  }))
+}
 
 export const findBPs = async (filter = {}) => mockedBPs
 
 export const findBPById = async id => mockedBPs[id]
+
+window.getAllBPs = getAllBPs

--- a/services/frontend/src/services/graphql.js
+++ b/services/frontend/src/services/graphql.js
@@ -1,7 +1,7 @@
 import ApolloClient from 'apollo-boost'
 
 const client = new ApolloClient({
-  uri: process.env.GRAPHQL_URL
+  uri: process.env.GRAPHQL_URL || 'http://localhost:8088/v1alpha1/graphql'
 })
 
 export default client


### PR DESCRIPTION
### Kanban Issue
Issue #17 

**IMPORTANT NOTE: THIS STILL NEEDS WORK!**

This still needs a place to point to consume the block producers from, right now the `.env` file is pointing at `localhost`, but we need a way to set this env var up on the different environments.

If this gets pushed, it will break production until we can configure a `graphql` consumable endpoint.

![image](https://user-images.githubusercontent.com/349542/49018514-3f36c880-f151-11e8-814a-8d61f56e05fd.png)
