### PR TITLE
fix(scripts): add yarn install to start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,6 +5,7 @@ docker-compose up -d
 # wait 10s for the docker services to start
 sleep 10s
 cd services/frontend
+yarn install
 yarn start
 
 cd ../..


### PR DESCRIPTION
Add `yarn install` before running `yarn start` in the start script