### PR TITLE
feat: mobile search layout behavior

### DIFF
--- a/services/frontend/src/components/app-bar.js
+++ b/services/frontend/src/components/app-bar.js
@@ -5,11 +5,13 @@ import AppBar from '@material-ui/core/AppBar'
 import Toolbar from '@material-ui/core/Toolbar'
 import IconButton from '@material-ui/core/IconButton'
 import MenuIcon from '@material-ui/icons/Menu'
+import SearchIcon from '@material-ui/icons/Search'
 import { fade } from '@material-ui/core/styles/colorManipulator'
 import FingerprintIcon from '@material-ui/icons/Fingerprint'
 import { Link } from '@reach/router'
 
 import InputAutocomplete from 'components/input-autocomplete'
+import MobileSearch from 'components/mobile-search'
 
 const styles = theme => ({
   root: {
@@ -44,19 +46,16 @@ const styles = theme => ({
     marginRight: theme.spacing.unit * 2,
     marginLeft: 0,
     width: '100%',
-    [theme.breakpoints.up('sm')]: {
-      marginLeft: theme.spacing.unit * 3,
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block',
       width: 'auto'
     }
   },
-  searchIcon: {
-    width: theme.spacing.unit * 9,
-    height: '100%',
-    position: 'absolute',
-    pointerEvents: 'none',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
+  mobileSearch: {
+    [theme.breakpoints.up('md')]: {
+      display: 'none'
+    }
   },
   inputRoot: {
     color: 'inherit',
@@ -75,7 +74,13 @@ const styles = theme => ({
   }
 })
 
-const MainTopBar = ({ classes, handleDrawerToggle }) => (
+const MainTopBar = ({
+  classes,
+  isSearchOpen,
+  handleDrawerToggle,
+  handleSearchDialogOpen,
+  handleSearchDialogClose
+}) => (
   <AppBar position='absolute'>
     <Toolbar>
       <IconButton
@@ -94,18 +99,30 @@ const MainTopBar = ({ classes, handleDrawerToggle }) => (
         <InputAutocomplete />
       </div>
       <div className={classes.grow} />
+      <IconButton
+        className={classes.mobileSearch}
+        color='inherit'
+        disabled={isSearchOpen}
+        onClick={handleSearchDialogOpen}
+      >
+        <SearchIcon />
+      </IconButton>
       <Link to='/account' className={classes.link}>
         <IconButton color='inherit'>
           <FingerprintIcon />
         </IconButton>
       </Link>
     </Toolbar>
+    <MobileSearch onClose={handleSearchDialogClose} isOpen={isSearchOpen} />
   </AppBar>
 )
 
 MainTopBar.propTypes = {
   classes: PropTypes.object,
-  handleDrawerToggle: PropTypes.func
+  handleDrawerToggle: PropTypes.func,
+  handleSearchDialogOpen: PropTypes.func,
+  handleSearchDialogClose: PropTypes.func,
+  isSearchOpen: PropTypes.bool
 }
 
 export default withStyles(styles)(MainTopBar)

--- a/services/frontend/src/components/input-autocomplete.js
+++ b/services/frontend/src/components/input-autocomplete.js
@@ -31,8 +31,13 @@ const style = theme => ({
     position: 'absolute',
     zIndex: 1,
     marginTop: theme.spacing.unit,
-    left: 0,
-    right: 0
+    left: '-24px',
+    right: 0,
+    width: '100vw',
+    [theme.breakpoints.up('md')]: {
+      left: 0,
+      width: 'auto'
+    }
   },
   highlightMatch: {
     fontWeight: 600
@@ -46,7 +51,10 @@ const style = theme => ({
     listStyleType: 'none'
   },
   inputAdornment: {
-    margin: '5px 25px'
+    margin: '5px 25px 5px 0',
+    [theme.breakpoints.up('md')]: {
+      margin: '5px 25px'
+    }
   },
   searchIcon: {
     fill: 'white'
@@ -65,10 +73,12 @@ class InputAutocomplete extends PureComponent {
 
   renderInputComponent = inputProps => {
     const { classes, inputRef = () => {}, ref, ...other } = inputProps
+    const { hideSearchIcon, isFocused } = this.props
 
     return (
       <TextField
         fullWidth
+        autoFocus={isFocused}
         InputProps={{
           inputRef: node => {
             ref(node)
@@ -76,7 +86,7 @@ class InputAutocomplete extends PureComponent {
           },
           disableUnderline: true,
           fullWidth: true,
-          startAdornment: (
+          startAdornment: hideSearchIcon ? null : (
             <InputAdornment className={classes.inputAdornment} position='start'>
               <SearchIcon className={classes.searchIcon} />
             </InputAdornment>
@@ -145,8 +155,10 @@ class InputAutocomplete extends PureComponent {
     })
   }
 
-  handleSelectedSuggestion = (event, { suggestion }) =>
+  handleSelectedSuggestion = (event, { suggestion }) => {
     navigate(`/block-producers/${suggestion.bpjson.producer_account_name}`)
+    this.props.onItemSelected()
+  }
 
   render () {
     const { classes, t } = this.props
@@ -198,7 +210,14 @@ class InputAutocomplete extends PureComponent {
 
 InputAutocomplete.propTypes = {
   classes: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  hideSearchIcon: PropTypes.bool,
+  onItemSelected: PropTypes.func,
+  isFocused: PropTypes.bool
+}
+
+InputAutocomplete.defaultProps = {
+  hideSearchIcon: false
 }
 
 export default withStyles(style)(

--- a/services/frontend/src/components/layout.js
+++ b/services/frontend/src/components/layout.js
@@ -38,16 +38,26 @@ const styles = theme => ({
 
 class Layout extends Component {
   state = {
-    isNavOpen: false
+    isNavOpen: false,
+    isSearchOpen: false
   }
 
   handleDrawerToggle = () => this.setState({ isNavOpen: !this.state.isNavOpen })
+
+  handleSearchDialogOpen = () => this.setState({ isSearchOpen: true })
+
+  handleSearchDialogClose = () => this.setState({ isSearchOpen: false })
 
   render () {
     const { classes, children } = this.props
     return (
       <div className={classes.root}>
-        <MainTopBar handleDrawerToggle={this.handleDrawerToggle} />
+        <MainTopBar
+          isSearchOpen={this.state.isSearchOpen}
+          handleDrawerToggle={this.handleDrawerToggle}
+          handleSearchDialogOpen={this.handleSearchDialogOpen}
+          handleSearchDialogClose={this.handleSearchDialogClose}
+        />
         <Hidden mdUp>
           <MainDrawer
             variant='mobile'

--- a/services/frontend/src/components/mobile-search.js
+++ b/services/frontend/src/components/mobile-search.js
@@ -1,0 +1,54 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import Dialog from '@material-ui/core/Dialog'
+import AppBar from '@material-ui/core/AppBar'
+import Toolbar from '@material-ui/core/Toolbar'
+import IconButton from '@material-ui/core/IconButton'
+import CloseIcon from '@material-ui/icons/Close'
+import Slide from '@material-ui/core/Slide'
+
+import InputAutocomplete from 'components/input-autocomplete'
+
+const styles = theme => ({
+  appBar: {
+    position: 'relative'
+  },
+  flex: {
+    flex: 1
+  }
+})
+
+const Transition = props => <Slide direction='up' {...props} />
+
+class MobileSearch extends PureComponent {
+  static propTypes = {
+    classes: PropTypes.object,
+    isOpen: PropTypes.bool,
+    onClose: PropTypes.func
+  }
+
+  render () {
+    const { classes, isOpen, onClose } = this.props
+
+    return (
+      <Dialog
+        fullScreen
+        open={isOpen}
+        onClose={onClose}
+        TransitionComponent={Transition}
+      >
+        <AppBar className={classes.appBar}>
+          <Toolbar>
+            <InputAutocomplete onItemSelected={onClose} isFocused={isOpen} />
+            <IconButton color='inherit' onClick={onClose} aria-label='Close'>
+              <CloseIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+      </Dialog>
+    )
+  }
+}
+
+export default withStyles(styles)(MobileSearch)


### PR DESCRIPTION
### GH Issue

#110 

### Steps to test

1. Open up the app
1. Go into mobile view through dev-tools
1. Click/tap on the search icon
1. A fullscreen dialog should appear with input already focused, and when searching for something, autocomplete should just work.
1. Either clicking or hitting enter should work the same, dialog should disappear and app should navigate to the block producer profile page.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [x] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [x] I have taken into consideration any impact to site performance.
