### PR TITLE
style(home) apply max width to rows in home page

### DIFF
--- a/services/frontend/src/routes/home/cover.js
+++ b/services/frontend/src/routes/home/cover.js
@@ -11,7 +11,8 @@ import bpParameters from 'config/comparison-parameters'
 
 const styles = ({ palette, typography }) => ({
   coverContainer: {
-    color: '#fff'
+    color: '#fff',
+    maxWidth: '1024px'
   },
   title: {
     fontSize: typography.h4.fontSize
@@ -29,7 +30,7 @@ const styles = ({ palette, typography }) => ({
 })
 
 const HomeCover = ({ classes, t, blockProducer }) => (
-  <Grid item container xs={12} className={classes.coverContainer} spacing={16}>
+  <Grid item container xs={12} className={classes.coverContainer} spacing={24}>
     <Grid item container xs={12} md={6} justify='center'>
       <div className={classes.chartContainer}>
         <BlockProducerRadar

--- a/services/frontend/src/routes/home/index.js
+++ b/services/frontend/src/routes/home/index.js
@@ -39,24 +39,28 @@ class Home extends Component {
           <Grid container direction='column'>
             <Grid item xs>
               {home.blockProducer && (
-                <div
+                <Grid
+                  container
+                  justify='center'
                   className={`${classes.spacingContainers}
                     ${classes.coverContainer}
                   `}
                 >
                   <Cover blockProducer={home.blockProducer} />
-                </div>
+                </Grid>
               )}
             </Grid>
 
             <Grid item xs>
-              <div
+              <Grid
+                container
+                justify='center'
                 className={`${classes.spacingContainers}
                 ${classes.subTopicContainer}
               `}
               >
                 <SubTopic />
-              </div>
+              </Grid>
             </Grid>
           </Grid>
         )}

--- a/services/frontend/src/routes/home/subTopic.js
+++ b/services/frontend/src/routes/home/subTopic.js
@@ -8,6 +8,9 @@ import PropTypes from 'prop-types'
 import Video from 'components/video'
 
 const styles = ({ palette, typography }) => ({
+  subTopicContainer: {
+    maxWidth: '1024px'
+  },
   title: {
     fontSize: typography.h4.fontSize,
     color: palette.grey[600]
@@ -23,7 +26,7 @@ const SubTopic = ({ classes, t }) => (
     container
     xs={12}
     className={classes.subTopicContainer}
-    spacing={16}
+    spacing={24}
   >
     <Grid item xs={12} md={7}>
       <Video src={t('subTopic.videoUrl')} />


### PR DESCRIPTION
### Max width #126

#

### Steps to test

1. Open up the app in desktop.
1. Go to home page.
1. Resize the browser to notice the max width applied.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [x] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [x] I have taken into consideration any impact to site performance.

#

![home](https://user-images.githubusercontent.com/8497609/50532004-32065400-0ad8-11e9-9802-ed823f6b3c54.gif)