### PR TITLE
fix(web): improve DOM performance loading less elements at once

### DIFF
--- a/services/frontend/src/components/block-producer-card.js
+++ b/services/frontend/src/components/block-producer-card.js
@@ -7,10 +7,7 @@ import CardHeader from '@material-ui/core/CardHeader'
 import Chip from '@material-ui/core/Chip'
 import CardActions from '@material-ui/core/CardActions'
 import Avatar from '@material-ui/core/Avatar'
-import IconButton from '@material-ui/core/IconButton'
-import AddIcon from '@material-ui/icons/Add'
-import RemoveIcon from '@material-ui/icons/Remove'
-import InfoIcon from '@material-ui/icons/Info'
+import Button from '@material-ui/core/Button'
 import ReportProblem from '@material-ui/icons/ReportProblem'
 import _get from 'lodash.get'
 import _isEmpty from 'lodash.isempty'
@@ -107,17 +104,12 @@ const BlockProducerCard = ({
       />
     </div>
     <CardActions className={classes.actions} disableActionSpacing>
-      <IconButton
+      <Button
         aria-label='Add to comparison'
         onClick={toggleSelection(!isSelected, blockProducer.owner)}
       >
-        {isSelected ? <RemoveIcon /> : <AddIcon />}
-      </IconButton>
-      <Link to={`/block-producers/${blockProducer.owner}`}>
-        <IconButton>
-          <InfoIcon />
-        </IconButton>
-      </Link>
+        {isSelected ? 'REMOVE' : 'ADD'}
+      </Button>
     </CardActions>
   </Card>
 )

--- a/services/frontend/src/components/compare-tool/compare-graph-view.js
+++ b/services/frontend/src/components/compare-tool/compare-graph-view.js
@@ -2,11 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
+import Chip from '@material-ui/core/Chip'
 import Typography from '@material-ui/core/Typography'
 import Avatar from '@material-ui/core/Avatar'
-import IconButton from '@material-ui/core/IconButton'
-import CloseIcon from '@material-ui/icons/Close'
+// import IconButton from '@material-ui/core/IconButton'
+// import CloseIcon from '@material-ui/icons/Close'
 import { withNamespaces } from 'react-i18next'
+import _get from 'lodash.get'
+import _isEmpty from 'lodash.isempty'
 
 import comparisonParameters from 'config/comparison-parameters'
 import BlockProducerRadar from 'components/block-producer-radar'
@@ -33,8 +36,9 @@ const styles = theme => ({
     verticalAlign: 'text-bottom'
   },
   bpName: {
-    padding: '0 0 0 10px',
-    display: 'inline'
+    margin: theme.spacing.unit,
+    color: 'white',
+    backgroundColor: theme.palette.primary.light
   }
 })
 
@@ -61,27 +65,30 @@ const CompareGraphView = ({
     <Grid item xs={12} md={4}>
       <Typography variant='h5'>{t('compareToolTitle')}</Typography>
       {selected.map(bp => (
-        <div
-          className={classes.bpItem}
-          key={`bp-list-name-${bp.bpjson.producer_account_name}`}
-        >
-          <div className={classes.bpNameWrapper}>
+        <Chip
+          className={classes.bpName}
+          avatar={
             <Avatar
-              className={classes.bpColorCode}
-              component='span'
+              aria-label='Block Producer'
               style={{ backgroundColor: bp.data.pointBackgroundColor }}
-            />
-            <Typography className={classes.bpName} component='span'>
-              {bp.bpjson.producer_account_name}
-            </Typography>
-          </div>
-          <IconButton
-            onClick={removeBP(bp.bpjson.producer_account_name)}
-            aria-label='Remove block producer'
-          >
-            <CloseIcon />
-          </IconButton>
-        </div>
+              className={classes.avatar}
+            >
+              {_isEmpty(bp.bpjson) ? (
+                'BP'
+              ) : (
+                <img
+                  src={_get(bp, 'bpjson.org.branding.logo_256')}
+                  alt=''
+                  width='100%'
+                />
+              )}
+            </Avatar>
+          }
+          color='secondary'
+          onDelete={removeBP(bp.owner)}
+          label={bp.owner}
+          key={`bp-list-name-${bp.owner}`}
+        />
       ))}
     </Grid>
   </Grid>

--- a/services/frontend/src/models/blockProducers.js
+++ b/services/frontend/src/models/blockProducers.js
@@ -23,7 +23,9 @@ const blockProducers = {
     setBPs (state, list) {
       // Whenever we get a new list, clear filters
       return {
-        ...initialState,
+        ...state,
+        filters: {},
+        filtered: [],
         list: list.map(bp => ({ ...bp }))
       }
     },

--- a/services/frontend/src/routes/block-producers/block-producer-profile.js
+++ b/services/frontend/src/routes/block-producers/block-producer-profile.js
@@ -80,7 +80,7 @@ const BlockProducerProfile = ({
                   <Grid item xs={4}>
                     <Grid container direction='row' alignItems='center'>
                       <AccountCircle className={classes.accountCircle} />
-                      <Typography variant='title' className={classes.bpName}>
+                      <Typography variant='h6' className={classes.bpName}>
                         {blockProducer.producer_account_name || ''}
                       </Typography>
                     </Grid>

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Grid from '@material-ui/core/Grid'
+import Badge from '@material-ui/core/Badge'
 import Button from '@material-ui/core/Button'
 import ExpandMore from '@material-ui/icons/ExpandMore'
 import ExpandLess from '@material-ui/icons/ExpandLess'
@@ -24,6 +25,10 @@ const style = theme => ({
     margin: theme.spacing.unit * 2,
     zIndex: 1
   },
+  badge: {
+    border: `2px solid ${theme.palette.secondary}`,
+    background: theme.palette.primary.sectionBackground
+  },
   wrapper: {
     padding: theme.spacing.unit * 3
   },
@@ -39,6 +44,10 @@ const style = theme => ({
       'min-height 0.25s ease'
     ]
   },
+  loadMoreButton: {
+    display: 'block',
+    margin: `${theme.spacing.unit * 2}px auto`
+  },
   hidden: {
     opacity: 0,
     transform: 'scaleY(0)',
@@ -48,9 +57,18 @@ const style = theme => ({
 })
 
 class AllBps extends Component {
+  state = {
+    currentlyVisible: 10
+  }
+
   componentDidMount () {
     this.props.getBPs()
   }
+
+  loadMore = () =>
+    this.setState(({ currentlyVisible }) => ({
+      currentlyVisible: currentlyVisible + 10
+    }))
 
   render () {
     const {
@@ -63,7 +81,11 @@ class AllBps extends Component {
       removeSelected,
       addToSelected
     } = this.props
+    const { currentlyVisible } = this.state
     const bpList = filtered.length ? filtered : blockProducers
+    const shownList = bpList.slice(0, currentlyVisible)
+
+    const hasMore = currentlyVisible < bpList.length
     return (
       <div className={classes.root}>
         <Button
@@ -73,7 +95,13 @@ class AllBps extends Component {
           className={classes.compareToggleButton}
           onClick={() => toggleCompareTool()}
         >
-          {compareToolVisible ? <ExpandLess /> : <ExpandMore />}
+          <Badge
+            classes={{ badge: classes.badge }}
+            invisible={!selectedBPs.length}
+            badgeContent={selectedBPs.length}
+          >
+            {compareToolVisible ? <ExpandLess /> : <ExpandMore />}
+          </Badge>
         </Button>
         <CompareTool
           removeBP={producerAccountName => () => {
@@ -91,7 +119,7 @@ class AllBps extends Component {
           justify='center'
           spacing={16}
         >
-          {bpList.map(blockProducer => (
+          {shownList.map(blockProducer => (
             <Grid
               item
               xs={12}
@@ -113,6 +141,12 @@ class AllBps extends Component {
             </Grid>
           ))}
         </Grid>
+        <Button
+          className={classes.loadMoreButton}
+          onClick={() => hasMore && this.loadMore()}
+        >
+          LOAD MORE
+        </Button>
       </div>
     )
   }
@@ -139,8 +173,8 @@ const mapStatetoProps = ({ blockProducers }) => ({
 })
 
 const mapDispatchToProps = ({
-  blockProducers: { getBPs, toggleCompareTool }
-}) => ({ getBPs, toggleCompareTool })
+  blockProducers: { getBPs, toggleCompareTool, addToSelected, removeSelected }
+}) => ({ getBPs, toggleCompareTool, addToSelected, removeSelected })
 
 export default withStyles(style)(
   withNamespaces('translations')(


### PR DESCRIPTION
### GH Issue

#54 

### Steps to test

1. Open up the block producers page.
1. Scroll all the way down and look for the `Load More` button
1. Hit that button, 10 more block producers should appear.
1. Hit the button again, and 10 more should appear, and so on until we run out of block producers.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [x] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [x] I have taken into consideration any impact to site performance.
