### PR TITLE
fix(web): remove unused settings route

### DIFF
--- a/services/frontend/src/routes/index.js
+++ b/services/frontend/src/routes/index.js
@@ -2,7 +2,7 @@ import Home from './home'
 import Account from './account'
 import BlockProducerProfile from './block-producers/block-producer-profile'
 import AllBps, { blockProducersDrawer } from './block-producers'
-import Settings from './settings'
+// import Settings from './settings'
 
 export default [
   {
@@ -20,11 +20,11 @@ export default [
     path: 'block-producers/:account',
     Component: BlockProducerProfile
   },
-  {
-    path: '/settings',
-    Component: Settings,
-    drawerLabel: 'drawerLinkSettings'
-  },
+  // {
+  //   path: '/settings',
+  //   Component: Settings,
+  //   drawerLabel: 'drawerLinkSettings'
+  // },
   {
     path: '/account',
     Component: Account


### PR DESCRIPTION
### GH Issue

#159 

### Steps to test

1. Open the side menu.
1. Confirm that the settings route is no longer visible.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [x] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [x] I have taken into consideration any impact to site performance.
