### PR TITLE
Update FAB in BPs page

### DIFF
--- a/services/frontend/src/language/en.json
+++ b/services/frontend/src/language/en.json
@@ -25,7 +25,10 @@
     "drawerLinkHome": "Home",
     "drawerLinkAllBPs": "Block Producers",
     "drawerLinkSettings": "Settings",
-    "drawerLinkAccount": "Account"
+    "drawerLinkAccount": "Account",
+
+    "hideComparisonTool": "Hide comparison tool",
+    "showComparisonTool": "Show comparison tool"
   },
 
   "not-found": {

--- a/services/frontend/src/language/es.json
+++ b/services/frontend/src/language/es.json
@@ -25,7 +25,10 @@
     "drawerLinkHome": "Página Principal",
     "drawerLinkAllBPs": "Productores de Bloques",
     "drawerLinkSettings": "Configuración",
-    "drawerLinkAccount": "Cuenta"
+    "drawerLinkAccount": "Cuenta",
+
+    "hideComparisonTool": "Ocultar herramienta de comparación",
+    "showComparisonTool": "Mostrar herramienta de comparación"
   },
 
   "not-found": {

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -4,9 +4,10 @@ import { connect } from 'react-redux'
 import Grid from '@material-ui/core/Grid'
 import Badge from '@material-ui/core/Badge'
 import Button from '@material-ui/core/Button'
-import ExpandMore from '@material-ui/icons/ExpandMore'
-import ExpandLess from '@material-ui/icons/ExpandLess'
 import { withStyles } from '@material-ui/core/styles'
+import Tooltip from '@material-ui/core/Tooltip'
+import VisibilityOff from '@material-ui/icons/VisibilityOff'
+import Visibility from '@material-ui/icons/Visibility'
 import { withNamespaces } from 'react-i18next'
 import classNames from 'classnames'
 
@@ -79,30 +80,36 @@ class AllBps extends Component {
       compareToolVisible,
       toggleCompareTool,
       removeSelected,
-      addToSelected
+      addToSelected,
+      t
     } = this.props
     const { currentlyVisible } = this.state
     const bpList = filtered.length ? filtered : blockProducers
     const shownList = bpList.slice(0, currentlyVisible)
 
     const hasMore = currentlyVisible < bpList.length
+    const fabLegend = compareToolVisible
+      ? t('hideComparisonTool')
+      : t('showComparisonTool')
     return (
       <div className={classes.root}>
-        <Button
-          variant='fab'
-          color='secondary'
-          aria-label='Toggle comparison tool visiblity'
-          className={classes.compareToggleButton}
-          onClick={() => toggleCompareTool()}
-        >
-          <Badge
-            classes={{ badge: classes.badge }}
-            invisible={!selectedBPs.length}
-            badgeContent={selectedBPs.length}
+        <Tooltip aria-label={fabLegend} placement='left' title={fabLegend}>
+          <Button
+            variant='fab'
+            color='secondary'
+            aria-label={fabLegend}
+            className={classes.compareToggleButton}
+            onClick={() => toggleCompareTool()}
           >
-            {compareToolVisible ? <ExpandLess /> : <ExpandMore />}
-          </Badge>
-        </Button>
+            <Badge
+              classes={{ badge: classes.badge }}
+              invisible={!selectedBPs.length}
+              badgeContent={selectedBPs.length}
+            >
+              {compareToolVisible ? <VisibilityOff /> : <Visibility />}
+            </Badge>
+          </Button>
+        </Tooltip>
         <CompareTool
           removeBP={producerAccountName => () => {
             removeSelected(producerAccountName)
@@ -154,7 +161,7 @@ class AllBps extends Component {
 
 AllBps.propTypes = {
   classes: PropTypes.object.isRequired,
-  // t: PropTypes.func.isRequired,
+  t: PropTypes.func.isRequired,
   blockProducers: PropTypes.array.isRequired,
   getBPs: PropTypes.func.isRequired,
   toggleCompareTool: PropTypes.func.isRequired,


### PR DESCRIPTION
### FAB Button functionality
Update the FAB (floating action button) in the block producers listing page to show up a visibility icon on and off with a tooltip.

#142

### Steps to test

1. Open the drawer menu.
2. Click in the "Block Producers" link.
3. The FAB is placed in the bottom right corner of the page.
4. Hover the FAB to see the tooltip.
5. Click the FAB to see how the icon and tooltip toggles and the tool is shown/hidden accordingly.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [X] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [X] I have taken into consideration any impact to site performance.
