### PR TITLE
Issue 226 User cannot push partials ratings

### DIFF
--- a/contracts/eoseosrateio/eoseosrateio.cpp
+++ b/contracts/eoseosrateio/eoseosrateio.cpp
@@ -4,7 +4,7 @@
 #include <eosiolib/multi_index.hpp>
 #include "rapidjson/document.h"
 
-#define MINVAL 1
+#define MINVAL 0
 #define MAXVAL 10
 #define MAXJSONSIZE 89
 
@@ -67,92 +67,170 @@ CONTRACT eoseosrateio : public contract {
            row.ratings_json = ratings_json;
          });
          //update the general data
-         process_json_stats(bp,ratings_json);
+        process_json_stats(bp,ratings_json);
 
        }
     }
 
     void process_json_stats(name bp_name,string ratings_json){
       Document json;
-      bp_rate_stats a_bp_stats;
+      bp_rate_stats a_bp_stats = {0,0,0,0,0};
+      bool flag = false;
       
       check(!(MAXJSONSIZE<ratings_json.length()),"Error json rating data too big");
       check( !(json.Parse<0>(ratings_json.c_str() ).HasParseError()) , "Error parsing json_rating" );
-      check( (json.HasMember("transparency")) , "Error json_rating doesn't provide transparency value" );
-      check( (json["transparency"].IsInt()) , "Error json_rating doesn't provide valid transparency value" );
-      check( (json.HasMember("infrastructure")) , "Error json_rating doesn't provide infrastructure value" );
-      check( (json["infrastructure"].IsInt()) , "Error json_rating doesn't provide valid infrastructure value" );
-      check( (json.HasMember("trustiness")) , "Error json_rating doesn't provide trustiness value" );
-      check( (json["trustiness"].IsInt()) , "Error json_rating doesn't provide valid trustiness value" );
-      check( (json.HasMember("development")) , "Error json_rating doesn't provide development value" );
-      check( (json["development"].IsInt()) , "Error json_rating doesn't provide valid development value" );
-      check( (json.HasMember("community")) , "Error json_rating doesn't provide community value" );
-      check( (json["community"].IsInt()) , "Error json_rating doesn't provide valid community value" );
-      a_bp_stats.transparency = json["transparency"].GetInt();
+
+      if(json.HasMember("transparency") && json["transparency"].IsInt()){
+          a_bp_stats.transparency = json["transparency"].GetInt();
+          flag=true;
+      }
       check( (MINVAL<=a_bp_stats.transparency && a_bp_stats.transparency<=MAXVAL ), "Error transparency value out of range" );
-      a_bp_stats.infrastructure = json["infrastructure"].GetInt();
+
+      if(json.HasMember("infrastructure") && json["infrastructure"].IsInt()){
+          a_bp_stats.infrastructure = json["infrastructure"].GetInt();
+          flag=true; 
+      }
       check( (MINVAL<=a_bp_stats.infrastructure && a_bp_stats.infrastructure<=MAXVAL ), "Error infrastructure value out of range" );
-      a_bp_stats.trustiness = json["trustiness"].GetInt();
+
+      if ( json.HasMember("trustiness") && json["trustiness"].IsInt() ){
+          a_bp_stats.trustiness = json["trustiness"].GetInt();
+          flag=true;
+      }
       check( (MINVAL<=a_bp_stats.trustiness && a_bp_stats.trustiness<=MAXVAL ), "Error trustiness value out of range" );
-      a_bp_stats.development = json["development"].GetInt();
+
+      if ( json.HasMember("development") && json["development"].IsInt() ){
+          a_bp_stats.development = json["development"].GetInt();
+          flag=true;
+      }
       check( (MINVAL<=a_bp_stats.development && a_bp_stats.development <=MAXVAL ), "Error development value out of range" );
-      a_bp_stats.community = json["community"].GetInt();
+
+
+      if ( json.HasMember("community") && json["community"].IsInt() ){
+          a_bp_stats.community = json["community"].GetInt();
+          flag=true;
+      }
       check( (MINVAL<=a_bp_stats.community && a_bp_stats.community<=MAXVAL ), "Error community value out of range" );
-      save_bp_stats(bp_name,&a_bp_stats);
+
+      if(flag){
+      	save_bp_stats(bp_name,&a_bp_stats);
+      }
       
     }
     
     void save_bp_stats (name bp_name, bp_rate_stats * bp_rate ){
       producers_stats_table bps_stats(_code, _code.value);
       auto itr = bps_stats.find(bp_name.value);
+      int counter =0;
+      int sum = 0;
       if(itr == bps_stats.end()){
         //new entry
          bps_stats.emplace(_self, [&]( auto& row ) {
-            row.bp = bp_name;
-            row.proxy_voters_cntr = 1;
-            row.transparency = bp_rate->transparency;
-            row.infrastructure = bp_rate->infrastructure;
-            row.trustiness = bp_rate->trustiness;
-            row.development = bp_rate->development;
-            row.community = bp_rate->community;
-            row.created_at = current_time();
-            row.updated_at = current_time();
+            
+            if (bp_rate->transparency){ 
+                row.transparency = bp_rate->transparency;
+                counter++;
+                sum += bp_rate->transparency;
+            }
+
+            if (bp_rate->infrastructure){
+                row.infrastructure = bp_rate->infrastructure;
+                counter++;
+                sum += bp_rate->infrastructure;
+            }
+
+            if (bp_rate->trustiness){ 
+                row.trustiness = bp_rate->trustiness;
+                counter++;
+                sum += bp_rate->trustiness;
+            }
+
+            if (bp_rate->development){
+                row.development = bp_rate->development;
+                counter++;
+                sum += bp_rate->development;
+            }
+
+            if (bp_rate->community){
+                row.community = bp_rate->community;
+                counter++;
+                sum += bp_rate->community;
+            }
+
+            if(counter){
+                row.bp = bp_name;
+                row.proxy_voters_cntr = 1;
+                row.average =sum/counter;  
+                row.created_at = current_time();
+                row.updated_at = current_time();
+            }
           });
       }else{
         //update the entry
         bps_stats.modify(itr,_self, [&]( auto& row ) {
-          row.bp = bp_name;
-          row.proxy_voters_cntr = row.proxy_voters_cntr + 1;
-          bp_rate->transparency = (bp_rate->transparency + row.transparency)/2;
-          bp_rate->infrastructure = (bp_rate->infrastructure + row.infrastructure)/2;
-          bp_rate->trustiness = (bp_rate->trustiness + row.trustiness)/2;
-          bp_rate->development  = (bp_rate->development + row.development)/2;
-          bp_rate->community = (bp_rate->community + row.community)/2;
-          row.transparency = bp_rate->transparency;
-          row.infrastructure = bp_rate->infrastructure;
-          row.trustiness = bp_rate->trustiness;
-          row.development = bp_rate->development;
-          row.community = bp_rate->community;
-          row.updated_at = current_time();
+          if (bp_rate->transparency){ 
+                sum += bp_rate->transparency; 
+                bp_rate->transparency = (bp_rate->transparency + row.transparency)/2;
+                row.transparency = bp_rate->transparency;
+                counter++;
+            }
+
+            if (bp_rate->infrastructure){
+                sum += bp_rate->infrastructure;
+                bp_rate->infrastructure = (bp_rate->infrastructure + row.infrastructure)/2;
+                row.infrastructure = bp_rate->infrastructure;
+                counter++;
+            }
+
+            if (bp_rate->trustiness){ 
+                sum += bp_rate->trustiness;
+                bp_rate->trustiness = (bp_rate->trustiness + row.trustiness)/2;
+                row.trustiness = bp_rate->trustiness;
+                counter++;
+            }
+
+            if (bp_rate->development){
+                sum += bp_rate->development;
+                bp_rate->development  = (bp_rate->development + row.development)/2;
+                row.development = bp_rate->development;
+                counter++;
+            }
+
+            if (bp_rate->community){
+                sum += bp_rate->community;
+                bp_rate->community = (bp_rate->community + row.community)/2;
+                row.community = bp_rate->community;
+                counter++;                
+            }
+
+            if(counter){
+                row.proxy_voters_cntr++;
+                row.average =( (sum/counter) + row.average ) /2; 
+                row.updated_at = current_time();
+            }		
          });
       }
     }
 
     // for dev only
-    ACTION erase() {
+    ACTION erase(string table) {
+      // table = bps or stats
       //only contract owner can erase table
       require_auth(_self);
 
-      producers_table bps(_code, _code.value);
-      auto itr = bps.begin();
-      while ( itr != bps.end()) {
-          itr = bps.erase(itr);
+      if(!table.compare("bps")){
+      	producers_table bps(_code, _code.value);
+      	auto itr = bps.begin();
+      	while ( itr != bps.end()) {
+      	    itr = bps.erase(itr);
+      	}
       }
 
-      producers_stats_table bps_stats(_code, _code.value);
-      auto itr_stats = bps_stats.begin();
-      while ( itr_stats != bps_stats.end()) {
-          itr_stats = bps_stats.erase(itr_stats);
+      if(!table.compare("stats")){
+      	producers_stats_table bps_stats(_code, _code.value);
+      	auto itr_stats = bps_stats.begin();
+      	while ( itr_stats != bps_stats.end()) {
+            itr_stats = bps_stats.erase(itr_stats);
+      	}
       }
     }
 
@@ -160,6 +238,7 @@ CONTRACT eoseosrateio : public contract {
     TABLE block_producers_stats {
       name bp;
       uint32_t proxy_voters_cntr;
+      float average;
       float transparency;
       float infrastructure;
       float trustiness;

--- a/contracts/eoseosrateio/eoseosrateio.cpp
+++ b/contracts/eoseosrateio/eoseosrateio.cpp
@@ -111,7 +111,7 @@ CONTRACT eoseosrateio : public contract {
     }
     
     void save_bp_stats (name bp_name, bp_rate_stats * bp_rate ){
-      producers_stats_table bps_stats(_code, _code.value);
+      producers_stats_table bps_stats(_self, _self.value);
       auto itr = bps_stats.find(bp_name.value);
       int counter =0;
       int sum = 0;
@@ -221,7 +221,7 @@ CONTRACT eoseosrateio : public contract {
       require_auth(_self);
 
       if(!table.compare("bps")){
-      	producers_table bps(_code, _code.value);
+      	producers_table bps(_self, _self.value);
       	auto itr = bps.begin();
       	while ( itr != bps.end()) {
       	    itr = bps.erase(itr);
@@ -229,7 +229,7 @@ CONTRACT eoseosrateio : public contract {
       }
 
       if(!table.compare("stats")){
-      	producers_stats_table bps_stats(_code, _code.value);
+      	producers_stats_table bps_stats(_self, _self.value);
       	auto itr_stats = bps_stats.begin();
       	while ( itr_stats != bps_stats.end()) {
             itr_stats = bps_stats.erase(itr_stats);


### PR DESCRIPTION
### Issue #226: User cannot push partials ratings

### Main Changes:
-  Allow partial ratings
-  Table name parameter added within action _erase_ 
-  Proxy restriction code deleted, due to is not filter accounts properly
-  Use (_self, _self.value) for the tables' memory allocation model

### Steps to test

# 1 complie
eosio-cpp eoseosrateio.cpp -o eoseosrateio.wasm -abigen -I  _**{CONTRACT PATH}**_

# 2 Publish.
cleos -u http://monitor.jungletestnet.io:8888 set contract eoseosrateio . -p eoseosrateio@active

# 3 push some ratings

### full ratings example
cleos -u http://monitor.jungletestnet.io:8888 push action eoseosrateio rateproducer '{ "user": "eoseosrateio", "bp": "alohaeostest", "ratings_json": "{\"transparency\":8,\"infrastructure\":8,\"trustiness\":7,\"development\":6,\"community\":10}" }' -p eoseosrateio@active

### partial ratings examples

cleos -u http://monitor.jungletestnet.io:8888 push action eoseosrateio rateproducer '{ "user": "eoseosrateio", "bp": "alohaeostest", "ratings_json": "{\"transparency\":8,\"infrastructure\":10}" }' -p eoseosrateio@active

cleos -u http://monitor.jungletestnet.io:8888 push action eoseosrateio rateproducer '{ "user": "eoseosrateio", "bp": "alohaeostest", "ratings_json": "{\"community\":9}" }' -p eoseosrateio@active

# Read tables:
### table stats
cleos -u http://monitor.jungletestnet.io:8888 get table eoseosrateio eoseosrateio stats
### table bps
cleos -u http://monitor.jungletestnet.io:8888 get table eoseosrateio eoseosrateio bps

# Clean tables:
### table stats
cleos -u http://monitor.jungletestnet.io:8888 push action eoseosrateio erase '{"table":"stats"}' -p eoseosrateio@active
### table bps
cleos -u http://monitor.jungletestnet.io:8888 push action eoseosrateio erase '{"table":"bps"}' -p eoseosrateio@active






