### PR TITLE
Fix/profile data

### DIFF
--- a/services/frontend/src/components/compare-tool/compare-graph-view.js
+++ b/services/frontend/src/components/compare-tool/compare-graph-view.js
@@ -51,7 +51,7 @@ const CompareGraphView = ({
 }) => {
   const { t } = useTranslation('translations')
   return (
-    <Grid container className={classes.root} spacing={16}>
+    <Grid container className={classes.root}>
       <Grid item xs={12} md={8}>
         <BlockProducerRadar
           bpData={{

--- a/services/frontend/src/components/input-autocomplete.js
+++ b/services/frontend/src/components/input-autocomplete.js
@@ -153,7 +153,7 @@ class InputAutocomplete extends PureComponent {
   }
 
   handleSelectedSuggestion = (event, { suggestion }) => {
-    navigate(`/block-producers/${suggestion.bpjson.producer_account_name}`)
+    navigate(`/block-producers/${suggestion.owner}`)
     this.props.onItemSelected && this.props.onItemSelected()
   }
 

--- a/services/frontend/src/components/language-select.js
+++ b/services/frontend/src/components/language-select.js
@@ -46,7 +46,7 @@ const LanguageSelect = ({ classes, style, alt }) => {
           className={classes.iconLanguage}
         />
         <Typography variant='h5' className={classes.languageText}>
-          {(i18n.language.substring(0, 2) || '').toLocaleUpperCase()}
+          {(i18n.language || '').toLocaleUpperCase().substring(0, 2)}
         </Typography>
       </div>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>

--- a/services/frontend/src/components/language-select.js
+++ b/services/frontend/src/components/language-select.js
@@ -46,7 +46,7 @@ const LanguageSelect = ({ classes, style, alt }) => {
           className={classes.iconLanguage}
         />
         <Typography variant='h5' className={classes.languageText}>
-          {(i18n.language || '').toLocaleUpperCase()}
+          {(i18n.language.substring(0, 2) || '').toLocaleUpperCase()}
         </Typography>
       </div>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>

--- a/services/frontend/src/components/mobile-search.js
+++ b/services/frontend/src/components/mobile-search.js
@@ -19,7 +19,7 @@ const styles = theme => ({
   }
 })
 
-const Transition = props => <Slide direction='up' {...props} />
+const Transition = React.forwardRef((props, ref) => <Slide direction='up' {...props} ref={ref} />)
 
 class MobileSearch extends PureComponent {
   static propTypes = {

--- a/services/frontend/src/models/BlockProducer/blockProducers.js
+++ b/services/frontend/src/models/BlockProducer/blockProducers.js
@@ -108,7 +108,7 @@ const blockProducers = {
             ({ owner }) => owner === blockProducer.owner
           )
 
-        this.addProducer({ ...blockProducer, system: { ...blockProducer.system, parameters: bpData.system.parameters }, data: bpData.data || [] })
+        this.addProducer({ ...blockProducer, average: bpData.average, system: { ...blockProducer.system, parameters: bpData.system.parameters }, data: bpData.data || [] })
         dispatch.isLoading.storeIsContentLoading(false)
       } catch (error) {
         console.error('getBlockProducerByOwner', error)

--- a/services/frontend/src/models/BlockProducer/blockProducers.js
+++ b/services/frontend/src/models/BlockProducer/blockProducers.js
@@ -1,4 +1,5 @@
 import filterObjects from 'filter-objects'
+import { navigate } from '@reach/router'
 import uniq from 'lodash.uniq'
 
 import apolloClient from 'services/graphql'
@@ -94,12 +95,21 @@ const blockProducers = {
     async getBlockProducerByOwner (owner, state) {
       try {
         dispatch.isLoading.storeIsContentLoading(true)
+
         const {
           data: { producers }
         } = await apolloClient.query({
           variables: { owner },
           query: QUERY_PRODUCER
         })
+
+        if (!producers.length) {
+          navigate('/not-found')
+          this.addProducer(null)
+          dispatch.isLoading.storeIsContentLoading(false)
+
+          return
+        }
 
         const blockProducer = producers[0]
         const bpData =

--- a/services/frontend/src/models/BlockProducer/blockProducers.js
+++ b/services/frontend/src/models/BlockProducer/blockProducers.js
@@ -118,7 +118,16 @@ const blockProducers = {
             ({ owner }) => owner === blockProducer.owner
           )
 
-        this.addProducer({ ...blockProducer, average: bpData.average, system: { ...blockProducer.system, parameters: bpData.system.parameters }, data: bpData.data || [] })
+        this.addProducer({
+          ...blockProducer,
+          average: bpData.average,
+          system: {
+            ...blockProducer.system,
+            votesInEos: bpData.system.votesInEos,
+            parameters: bpData.system.parameters
+          },
+          data: bpData.data || []
+        })
         dispatch.isLoading.storeIsContentLoading(false)
       } catch (error) {
         console.error('getBlockProducerByOwner', error)
@@ -228,7 +237,9 @@ const blockProducers = {
 
           return producer
         })
-        const currentBP = producerUpdatedList.find(producer => producer.owner === bp)
+        const currentBP = producerUpdatedList.find(
+          producer => producer.owner === bp
+        )
 
         dataResponse.length && this.addUserRate(dataResponse[0].ratings)
         this.addProducer(currentBP)

--- a/services/frontend/src/routes/account/index.js
+++ b/services/frontend/src/routes/account/index.js
@@ -62,7 +62,7 @@ const Account = ({ classes }) => {
   }
 
   return (
-    <Grid container spacing={16} className={classes.container}>
+    <Grid container className={classes.container}>
       <Grid item xs={12}>
         <Paper className={classes.account}>
           <Typography variant='h5' className={classnames(classes.title)}>

--- a/services/frontend/src/routes/block-producers/block-producer-profile.js
+++ b/services/frontend/src/routes/block-producers/block-producer-profile.js
@@ -109,7 +109,7 @@ const BlockProducerProfile = ({
 }) => {
   const { t } = useTranslation('bpProfile')
   const bpHasInformation = Boolean(producer && Object.values(producer.bpjson).length)
-  const bPLogo = bpHasInformation ? producer.bpjson.org.branding.logo_256 : null
+  const bPLogo = bpHasInformation && _get(producer, 'bpjson.org.branding.logo_256', null)
   const BlockProducerTitle = _get(producer, 'bpjson.org.candidate_name', _get(producer, 'system.owner', 'No Data'))
 
   useEffect(() => {

--- a/services/frontend/src/routes/block-producers/block-producer-profile.js
+++ b/services/frontend/src/routes/block-producers/block-producer-profile.js
@@ -13,6 +13,7 @@ import { withStyles } from '@material-ui/core/styles'
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
 import AccountCircle from '@material-ui/icons/AccountCircle'
 import Divider from '@material-ui/core/Divider'
+import _get from 'lodash.get'
 
 import BlockProducerRadar from 'components/block-producer-radar'
 import bpParameters from 'config/comparison-parameters'
@@ -91,6 +92,10 @@ const style = theme => ({
     [theme.breakpoints.up('sm')]: {
       margin: 0
     }
+  },
+  links: {
+    textDecoration: 'none',
+    color: theme.palette.secondary.light
   }
 })
 
@@ -105,6 +110,9 @@ const BlockProducerProfile = ({
   const { t } = useTranslation('bpProfile')
   const bpHasInformation = Boolean(producer && Object.values(producer.bpjson).length)
   const bPLogo = bpHasInformation ? producer.bpjson.org.branding.logo_256 : null
+  const BlockProducerTitle = _get(producer, 'bpjson.org.candidate_name', _get(producer, 'system.owner', 'No Data'))
+
+  console.log({ producer })
 
   useEffect(() => {
     getBlockProducer(account)
@@ -146,11 +154,7 @@ const BlockProducerProfile = ({
                         <AccountCircle className={classes.accountCircle} />
                       )}
                       <Typography variant='h6' className={classes.bpName}>
-                        {bpHasInformation
-                          ? producer.bpjson.org.candidate_name
-                          : producer
-                            ? producer.system.owner
-                            : 'No Data'}
+                        {BlockProducerTitle}
                       </Typography>
                       {!bpHasInformation && (
                         <Typography variant='h6' className={classes.bpName}>

--- a/services/frontend/src/routes/block-producers/block-producer-profile.js
+++ b/services/frontend/src/routes/block-producers/block-producer-profile.js
@@ -112,16 +112,14 @@ const BlockProducerProfile = ({
   const bPLogo = bpHasInformation ? producer.bpjson.org.branding.logo_256 : null
   const BlockProducerTitle = _get(producer, 'bpjson.org.candidate_name', _get(producer, 'system.owner', 'No Data'))
 
-  console.log({ producer })
-
   useEffect(() => {
     getBlockProducer(account)
   }, [account])
 
   return (
-    <Grid container justify='center' spacing={16} className={classes.container}>
+    <Grid container justify='center' className={classes.container}>
       <Grid item xs={12}>
-        <Grid container spacing={16} direction='row' alignItems='center'>
+        <Grid container direction='row' alignItems='center'>
           <Button
             component={props => <Link {...props} to='/block-producers' />}
           >

--- a/services/frontend/src/routes/block-producers/block-producer-rate.js
+++ b/services/frontend/src/routes/block-producers/block-producer-rate.js
@@ -96,7 +96,8 @@ const BlockProducerRate = ({
   producer,
   getBPRating,
   addUserRating,
-  userRate
+  userRate,
+  getBlockProducer
 }) => {
   const walletState = useWalletState()
   const [ratingState, setRatingState] = useState(INIT_RATING_STATE_DATA)
@@ -104,13 +105,18 @@ const BlockProducerRate = ({
   const { t } = useTranslation('bpRatePage')
   const wallet = walletState.wallet
   const accountName = wallet && wallet.auth.accountName
+  const bpData = _get(producer, 'data', {})
 
   useEffect(() => {
+    if (account) {
+      getBlockProducer(account)
+    }
+
     if (accountName) {
       getBPRating({ bp: account, userAccount: accountName })
       setShowMessage(false)
     }
-  }, [accountName])
+  }, [accountName, account])
 
   useEffect(() => {
     if (userRate) {
@@ -242,7 +248,7 @@ const BlockProducerRate = ({
             component={props => <Link {...props} to='/block-producers' />}
           >
             <KeyboardArrowLeft />
-            {t('allBP')}
+            {t('allBPs')}
           </Button>
           <Button
             component={props => (
@@ -312,7 +318,7 @@ const BlockProducerRate = ({
                       bpData={{
                         labels: bpParameters,
                         datasets: [
-                          { ...producer.data, label: t('globalRate') },
+                          { ...bpData, label: t('globalRate') },
                           userDataSet
                         ]
                       }}
@@ -405,7 +411,8 @@ BlockProducerRate.propTypes = {
   producer: PropTypes.object,
   getBPRating: PropTypes.func,
   addUserRating: PropTypes.func,
-  userRate: PropTypes.object
+  userRate: PropTypes.object,
+  getBlockProducer: PropTypes.func
 }
 
 const mapStateToProps = ({ blockProducers: { producer, userRate } }) => ({
@@ -415,7 +422,8 @@ const mapStateToProps = ({ blockProducers: { producer, userRate } }) => ({
 
 const mapDispatchToProps = dispatch => ({
   getBPRating: dispatch.blockProducers.getBlockProducerRatingByOwner,
-  addUserRating: dispatch.blockProducers.mutationInsertUserRating
+  addUserRating: dispatch.blockProducers.mutationInsertUserRating,
+  getBlockProducer: dispatch.blockProducers.getBlockProducerByOwner
 })
 
 export default withStyles(style)(

--- a/services/frontend/src/routes/block-producers/block-producer-rate.js
+++ b/services/frontend/src/routes/block-producers/block-producer-rate.js
@@ -19,6 +19,7 @@ import CheckCircle from '@material-ui/icons/CheckCircle'
 import Error from '@material-ui/icons/Error'
 import HelpOutline from '@material-ui/icons/HelpOutline'
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
+import _get from 'lodash.get'
 import { withStyles } from '@material-ui/core/styles'
 
 import BlockProducerRadar from 'components/block-producer-radar'
@@ -249,8 +250,7 @@ const BlockProducerRate = ({
   const handleStateChange = parameter => (event, value) =>
     setRatingState({ ...ratingState, [parameter]: value })
 
-  const bPLogo =
-    producer && producer.bpjson ? producer.bpjson.org.branding.logo_256 : null
+  const bPLogo = _get(producer, 'bpjson.org.branding.logo_256', null)
 
   return (
     <Grid container justify='center' spacing={16} className={classes.container}>

--- a/services/frontend/src/routes/block-producers/general-information-profile.js
+++ b/services/frontend/src/routes/block-producers/general-information-profile.js
@@ -5,10 +5,18 @@ import { useTranslation } from 'react-i18next'
 import { Link } from '@reach/router'
 import Button from '@material-ui/core/Button'
 import Grid from '@material-ui/core/Grid'
+import _get from 'lodash.get'
 import Typography from '@material-ui/core/Typography'
+
+import formatNumber from 'utils/formatNumber' 
 
 const SocialNetworks = ({ classes, overrideClass, producer }) => {
   const { t } = useTranslation('bpProfile')
+  const github = _get(producer, 'org.social.github') 
+  const twitter = _get(producer, 'org.social.twitter') 
+  const linkedin = _get(producer, 'org.social.linkedin') 
+  const telegram = _get(producer, 'org.social.telegram')
+  const instagram = _get(producer, 'org.social.instagram') 
 
   return (
     <Grid
@@ -19,7 +27,7 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
       <Typography variant='subtitle1' className={classes.title}>
         {t('social')}
       </Typography>
-      <Grid container direction='row'>
+      {github && <Grid container direction='row'>
         <Typography variant='subtitle1' className={classes.subTitle}>
           GitHub:
         </Typography>
@@ -27,10 +35,10 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
           variant='subtitle1'
           className={classNames(classes.value, classes.subTitle)}
         >
-          {(producer && producer.org.social.github) || '- -'}
+          <a href={`https://github.com/${github}`} className={classes.links} target="_blank">{github}</a>
         </Typography>
-      </Grid>
-      <Grid container direction='row'>
+      </Grid>}
+      {twitter && <Grid container direction='row'>
         <Typography variant='subtitle1' className={classes.subTitle}>
           Twitter:
         </Typography>
@@ -38,10 +46,10 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
           variant='subtitle1'
           className={classNames(classes.value, classes.subTitle)}
         >
-          {(producer && producer.org.social.twitter) || '- -'}
+          <a href={`https://twitter.com/${twitter}`} className={classes.links} target="_blank">{twitter}</a>
         </Typography>
-      </Grid>
-      <Grid container direction='row'>
+      </Grid>}
+      {linkedin && <Grid container direction='row'>
         <Typography variant='subtitle1' className={classes.subTitle}>
           LinkedIn:
         </Typography>
@@ -49,10 +57,10 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
           variant='subtitle1'
           className={classNames(classes.value, classes.subTitle)}
         >
-          {(producer && producer.org.social.linkedin) || '- -'}
+          <a href={`https://www.linkedin.com/in/${linkedin}`} className={classes.links} target="_blank">{linkedin}</a>
         </Typography>
-      </Grid>
-      <Grid container direction='row'>
+      </Grid>}
+      {telegram && <Grid container direction='row'>
         <Typography variant='subtitle1' className={classes.subTitle}>
           Telegram:
         </Typography>
@@ -60,10 +68,10 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
           variant='subtitle1'
           className={classNames(classes.value, classes.subTitle)}
         >
-          {(producer && producer.org.social.telegram) || '- -'}
+          <a href={`https://web.telegram.org/#/${telegram}`} className={classes.links} target="_blank">{telegram}</a>
         </Typography>
-      </Grid>
-      <Grid container direction='row'>
+      </Grid>}
+      {instagram && <Grid container direction='row'>
         <Typography variant='subtitle1' className={classes.subTitle}>
           Instagram:
         </Typography>
@@ -71,9 +79,9 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
           variant='subtitle1'
           className={classNames(classes.value, classes.subTitle)}
         >
-          {(producer && producer.org.social.instagram) || '- -'}
+          <a href={`https://www.instagram.com/${instagram}`} className={classes.links} target="_blank">{instagram}</a>
         </Typography>
-      </Grid>
+      </Grid>}
     </Grid>
   )
 }
@@ -100,6 +108,8 @@ const WebsiteLegend = ({ classes, overrideClass }) => {
 
 const GeneralInformation = ({ classes, producer, overrideClass }) => {
   const { t } = useTranslation('bpProfile')
+  const webpageURL = _get(producer, 'system.url')
+  const totalVotes = _get(producer, 'system.total_votes') || 0
 
   return (
     <>
@@ -115,7 +125,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {(producer && producer.system.owner) || '- -'}
+            {_get(producer, 'system.owner', '- -')}
           </Typography>
         </Grid>
         <Grid container direction='row'>
@@ -126,7 +136,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {(producer && producer.system.location) || '- -'}
+            {_get(producer, 'system.location', '- -')}
           </Typography>
         </Grid>
         <Grid container direction='row'>
@@ -137,7 +147,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {(producer && producer.system.url) || '- -'}
+            {webpageURL ? <a href={webpageURL} className={classes.links} target="_blank">{webpageURL}</a> : '- -'}
           </Typography>
         </Grid>
       </Grid>
@@ -154,7 +164,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {(producer && producer.system.total_votes) || '- -'}
+            {formatNumber(parseFloat(totalVotes), 2)}
           </Typography>
         </Grid>
         <Grid container direction='row'>
@@ -176,7 +186,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            - -
+            {_get(producer, 'average') || 0}
           </Typography>
         </Grid>
       </Grid>
@@ -187,8 +197,7 @@ const GeneralInformation = ({ classes, producer, overrideClass }) => {
             component={props => (
               <Link
                 {...props}
-                to={`/block-producers/${(producer && producer.owner) ||
-                  'noBlockProducerName'}/rate`}
+                to={`/block-producers/${_get(producer, 'owner', 'noBlockProducerName')}/rate`}
               />
             )}
             className={classes.btnBP}

--- a/services/frontend/src/routes/block-producers/general-information-profile.js
+++ b/services/frontend/src/routes/block-producers/general-information-profile.js
@@ -18,12 +18,12 @@ const _getCountryName = (country = null, locationNumber, defaultMessage) => {
   const { i18n } = useTranslation()
   const countryNameByLocationNumber = countries.getName(
     locationNumber,
-    i18n.language
+    i18n.language.substring(0, 2)
   )
 
   if (countryNameByLocationNumber) return countryNameByLocationNumber
 
-  const countryNameByISO = countries.getName(country, i18n.language)
+  const countryNameByISO = countries.getName(country, i18n.language.substring(0, 2))
 
   if (countryNameByISO) return countryNameByISO
 
@@ -32,11 +32,11 @@ const _getCountryName = (country = null, locationNumber, defaultMessage) => {
 
 const SocialNetworks = ({ classes, overrideClass, producer }) => {
   const { t } = useTranslation('bpProfile')
-  const github = _get(producer, 'org.social.github') 
-  const twitter = _get(producer, 'org.social.twitter') 
-  const linkedin = _get(producer, 'org.social.linkedin') 
+  const github = _get(producer, 'org.social.github')
+  const twitter = _get(producer, 'org.social.twitter')
+  const linkedin = _get(producer, 'org.social.linkedin')
   const telegram = _get(producer, 'org.social.telegram')
-  const instagram = _get(producer, 'org.social.instagram') 
+  const instagram = _get(producer, 'org.social.instagram')
 
   return (
     <Grid
@@ -47,61 +47,106 @@ const SocialNetworks = ({ classes, overrideClass, producer }) => {
       <Typography variant='subtitle1' className={classes.title}>
         {t('social')}
       </Typography>
-      {github && <Grid container direction='row'>
-        <Typography variant='subtitle1' className={classes.subTitle}>
-          GitHub:
-        </Typography>
-        <Typography
-          variant='subtitle1'
-          className={classNames(classes.value, classes.subTitle)}
-        >
-          <a href={`https://github.com/${github}`} className={classes.links} target="_blank">{github}</a>
-        </Typography>
-      </Grid>}
-      {twitter && <Grid container direction='row'>
-        <Typography variant='subtitle1' className={classes.subTitle}>
-          Twitter:
-        </Typography>
-        <Typography
-          variant='subtitle1'
-          className={classNames(classes.value, classes.subTitle)}
-        >
-          <a href={`https://twitter.com/${twitter}`} className={classes.links} target="_blank">{twitter}</a>
-        </Typography>
-      </Grid>}
-      {linkedin && <Grid container direction='row'>
-        <Typography variant='subtitle1' className={classes.subTitle}>
-          LinkedIn:
-        </Typography>
-        <Typography
-          variant='subtitle1'
-          className={classNames(classes.value, classes.subTitle)}
-        >
-          <a href={`https://www.linkedin.com/in/${linkedin}`} className={classes.links} target="_blank">{linkedin}</a>
-        </Typography>
-      </Grid>}
-      {telegram && <Grid container direction='row'>
-        <Typography variant='subtitle1' className={classes.subTitle}>
-          Telegram:
-        </Typography>
-        <Typography
-          variant='subtitle1'
-          className={classNames(classes.value, classes.subTitle)}
-        >
-          <a href={`https://web.telegram.org/#/${telegram}`} className={classes.links} target="_blank">{telegram}</a>
-        </Typography>
-      </Grid>}
-      {instagram && <Grid container direction='row'>
-        <Typography variant='subtitle1' className={classes.subTitle}>
-          Instagram:
-        </Typography>
-        <Typography
-          variant='subtitle1'
-          className={classNames(classes.value, classes.subTitle)}
-        >
-          <a href={`https://www.instagram.com/${instagram}`} className={classes.links} target="_blank">{instagram}</a>
-        </Typography>
-      </Grid>}
+      {github && (
+        <Grid container direction='row'>
+          <Typography variant='subtitle1' className={classes.subTitle}>
+            GitHub:
+          </Typography>
+          <Typography
+            variant='subtitle1'
+            className={classNames(classes.value, classes.subTitle)}
+          >
+            <a
+              href={`https://github.com/${github}`}
+              className={classes.links}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {github}
+            </a>
+          </Typography>
+        </Grid>
+      )}
+      {twitter && (
+        <Grid container direction='row'>
+          <Typography variant='subtitle1' className={classes.subTitle}>
+            Twitter:
+          </Typography>
+          <Typography
+            variant='subtitle1'
+            className={classNames(classes.value, classes.subTitle)}
+          >
+            <a
+              href={`https://twitter.com/${twitter}`}
+              className={classes.links}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {twitter}
+            </a>
+          </Typography>
+        </Grid>
+      )}
+      {linkedin && (
+        <Grid container direction='row'>
+          <Typography variant='subtitle1' className={classes.subTitle}>
+            LinkedIn:
+          </Typography>
+          <Typography
+            variant='subtitle1'
+            className={classNames(classes.value, classes.subTitle)}
+          >
+            <a
+              href={`https://www.linkedin.com/in/${linkedin}`}
+              className={classes.links}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {linkedin}
+            </a>
+          </Typography>
+        </Grid>
+      )}
+      {telegram && (
+        <Grid container direction='row'>
+          <Typography variant='subtitle1' className={classes.subTitle}>
+            Telegram:
+          </Typography>
+          <Typography
+            variant='subtitle1'
+            className={classNames(classes.value, classes.subTitle)}
+          >
+            <a
+              href={`https://web.telegram.org/#/${telegram}`}
+              className={classes.links}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {telegram}
+            </a>
+          </Typography>
+        </Grid>
+      )}
+      {instagram && (
+        <Grid container direction='row'>
+          <Typography variant='subtitle1' className={classes.subTitle}>
+            Instagram:
+          </Typography>
+          <Typography
+            variant='subtitle1'
+            className={classNames(classes.value, classes.subTitle)}
+          >
+            <a
+              href={`https://www.instagram.com/${instagram}`}
+              className={classes.links}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {instagram}
+            </a>
+          </Typography>
+        </Grid>
+      )}
     </Grid>
   )
 }
@@ -130,7 +175,6 @@ const GeneralInformation = ({ classes, producer }) => {
   const { t } = useTranslation('bpProfile')
   const webpageURL = _get(producer, 'system.url')
   const totalVotes = _get(producer, 'system.total_votes') || 0
-  
   const countryName = _getCountryName(
     _get(producer, 'bpjson.org.location.country', null),
     _get(producer, 'system.location', null),
@@ -173,7 +217,18 @@ const GeneralInformation = ({ classes, producer }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {webpageURL ? <a href={webpageURL} className={classes.links} target="_blank">{webpageURL}</a> : '- -'}
+            {webpageURL ? (
+              <a
+                href={webpageURL}
+                className={classes.links}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                {webpageURL}
+              </a>
+            ) : (
+              '- -'
+            )}
           </Typography>
         </Grid>
       </Grid>
@@ -223,7 +278,11 @@ const GeneralInformation = ({ classes, producer }) => {
             component={props => (
               <Link
                 {...props}
-                to={`/block-producers/${_get(producer, 'owner', 'noBlockProducerName')}/rate`}
+                to={`/block-producers/${_get(
+                  producer,
+                  'owner',
+                  'noBlockProducerName'
+                )}/rate`}
               />
             )}
             className={classes.btnBP}

--- a/services/frontend/src/routes/block-producers/general-information-profile.js
+++ b/services/frontend/src/routes/block-producers/general-information-profile.js
@@ -16,14 +16,15 @@ countries.registerLocale(require('i18n-iso-countries/langs/es.json'))
 
 const _getCountryName = (country = null, locationNumber, defaultMessage) => {
   const { i18n } = useTranslation()
+  const language = (i18n.language || 'en').substring(0, 2)
   const countryNameByLocationNumber = countries.getName(
     locationNumber,
-    i18n.language.substring(0, 2)
+    language
   )
 
   if (countryNameByLocationNumber) return countryNameByLocationNumber
 
-  const countryNameByISO = countries.getName(country, i18n.language.substring(0, 2))
+  const countryNameByISO = countries.getName(country, language)
 
   if (countryNameByISO) return countryNameByISO
 
@@ -174,7 +175,7 @@ const WebsiteLegend = ({ classes }) => {
 const GeneralInformation = ({ classes, producer }) => {
   const { t } = useTranslation('bpProfile')
   const webpageURL = _get(producer, 'system.url')
-  const totalVotes = _get(producer, 'system.total_votes') || 0
+  const totalVotes = _get(producer, 'system.votesInEos') || 0
   const countryName = _getCountryName(
     _get(producer, 'bpjson.org.location.country', null),
     _get(producer, 'system.location', null),
@@ -245,7 +246,7 @@ const GeneralInformation = ({ classes, producer }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {formatNumber(parseFloat(totalVotes), 2)}
+            {formatNumber(parseFloat(totalVotes), 0)}
           </Typography>
         </Grid>
         <Grid container direction='row'>
@@ -267,7 +268,7 @@ const GeneralInformation = ({ classes, producer }) => {
             variant='subtitle1'
             className={classNames(classes.value, classes.subTitle)}
           >
-            {_get(producer, 'average') || 0}
+            {(_get(producer, 'average') || 0).toFixed(2)}
           </Typography>
         </Grid>
       </Grid>

--- a/services/frontend/src/routes/block-producers/slider-rating-section.js
+++ b/services/frontend/src/routes/block-producers/slider-rating-section.js
@@ -1,0 +1,223 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { Grid, Switch, Tooltip, Typography } from '@material-ui/core'
+import { withStyles } from '@material-ui/core/styles'
+import HelpOutline from '@material-ui/icons/HelpOutline'
+
+import RateSlider from 'components/rate-slider'
+
+const MARKS = [
+  { value: 0 },
+  { value: 1 },
+  { value: 2 },
+  { value: 3 },
+  { value: 4 },
+  { value: 5 },
+  { value: 6 },
+  { value: 7 },
+  { value: 8 },
+  { value: 9 },
+  { value: 10 }
+]
+
+const style = () => ({
+  sliderWrapper: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  sliderBoxContent: { marginTop: 30 },
+  marginOff: { margin: 0 },
+  parameterTitleDisabled: {
+    color: '#bdbdbd'
+  },
+  topicIcon: {
+    color: 'rgba(255, 255, 255, 0.38)',
+    verticalAlign: 'middle'
+  }
+})
+
+const SliderRatingSection = ({
+  t,
+  handleStateChange,
+  ratingState,
+  classes
+}) => {
+  return (
+    <Grid container className={classes.sliderBoxContent}>
+      <Grid item xs={12}>
+        <Typography
+          paragraph
+          className={classNames(
+            ratingState.communityEnabled ? '' : classes.parameterTitleDisabled,
+            classes.marginOff
+          )}
+        >
+          {t('community')}{' '}
+          <Tooltip title={t('communityTooltip')} placement='right'>
+            <HelpOutline fontSize='inherit' className={classes.topicIcon} />
+          </Tooltip>
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <div className={classes.sliderWrapper}>
+          <RateSlider
+            disabled={!ratingState.communityEnabled}
+            onChange={handleStateChange('community')}
+            value={ratingState.community}
+            marks={MARKS}
+            valueLabelDisplay='on'
+            min={0}
+            step={1}
+            max={10}
+          />
+          <Switch
+            onChange={handleStateChange('communityEnabled')}
+            checked={ratingState.communityEnabled}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography
+          paragraph
+          className={classNames(
+            ratingState.developmentEnabled
+              ? ''
+              : classes.parameterTitleDisabled,
+            classes.marginOff
+          )}
+        >
+          {t('development')}{' '}
+          <Tooltip title={t('developmentTooltip')} placement='right'>
+            <HelpOutline fontSize='inherit' className={classes.topicIcon} />
+          </Tooltip>
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <div className={classes.sliderWrapper}>
+          <RateSlider
+            disabled={!ratingState.developmentEnabled}
+            onChange={handleStateChange('development')}
+            value={ratingState.development}
+            marks={MARKS}
+            valueLabelDisplay='on'
+            min={0}
+            step={1}
+            max={10}
+          />
+          <Switch
+            onChange={handleStateChange('developmentEnabled')}
+            checked={ratingState.developmentEnabled}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography
+          paragraph
+          className={classNames(
+            ratingState.infraEnabled ? '' : classes.parameterTitleDisabled,
+            classes.marginOff
+          )}
+        >
+          {t('infrastructure')}{' '}
+          <Tooltip title={t('infrastructureTooltip')} placement='right'>
+            <HelpOutline fontSize='inherit' className={classes.topicIcon} />
+          </Tooltip>
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <div className={classes.sliderWrapper}>
+          <RateSlider
+            disabled={!ratingState.infraEnabled}
+            onChange={handleStateChange('infra')}
+            value={ratingState.infra}
+            marks={MARKS}
+            valueLabelDisplay='on'
+            min={0}
+            step={1}
+            max={10}
+          />
+          <Switch
+            onChange={handleStateChange('infraEnabled')}
+            checked={ratingState.infraEnabled}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography
+          paragraph
+          className={classNames(
+            ratingState.transparencyEnabled
+              ? ''
+              : classes.parameterTitleDisabled,
+            classes.marginOff
+          )}
+        >
+          {t('transparency')}{' '}
+          <Tooltip title={t('transparencyTooltip')} placement='right'>
+            <HelpOutline fontSize='inherit' className={classes.topicIcon} />
+          </Tooltip>
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <div className={classes.sliderWrapper}>
+          <RateSlider
+            disabled={!ratingState.transparencyEnabled}
+            onChange={handleStateChange('transparency')}
+            value={ratingState.transparency}
+            marks={MARKS}
+            valueLabelDisplay='on'
+            min={0}
+            step={1}
+            max={10}
+          />
+          <Switch
+            onChange={handleStateChange('transparencyEnabled')}
+            checked={ratingState.transparencyEnabled}
+          />
+        </div>
+      </Grid>
+      <Grid item xs={12}>
+        <Typography
+          paragraph
+          className={classNames(
+            ratingState.trustinessEnabled ? '' : classes.parameterTitleDisabled,
+            classes.marginOff
+          )}
+        >
+          {t('trustiness')}{' '}
+          <Tooltip title={t('trustinessTooltip')} placement='right'>
+            <HelpOutline fontSize='inherit' className={classes.topicIcon} />
+          </Tooltip>
+        </Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <div className={classes.sliderWrapper}>
+          <RateSlider
+            disabled={!ratingState.trustinessEnabled}
+            onChange={handleStateChange('trustiness')}
+            value={ratingState.trustiness}
+            marks={MARKS}
+            valueLabelDisplay='on'
+            min={0}
+            step={1}
+            max={10}
+          />
+          <Switch
+            onChange={handleStateChange('trustinessEnabled')}
+            checked={ratingState.trustinessEnabled}
+          />
+        </div>
+      </Grid>
+    </Grid>
+  )
+}
+
+SliderRatingSection.propTypes = {
+  classes: PropTypes.object,
+  t: PropTypes.any,
+  handleStateChange: PropTypes.func,
+  ratingState: PropTypes.object
+}
+
+export default withStyles(style)(SliderRatingSection)

--- a/services/frontend/src/routes/home/cover.js
+++ b/services/frontend/src/routes/home/cover.js
@@ -54,7 +54,6 @@ const HomeCover = ({ classes, blockProducer }) => {
       container
       xs={12}
       className={classes.coverContainer}
-      spacing={24}
     >
       <Grid item xs={12} md={6} className={classes.leftCoverBox}>
         <Typography variant='h5' className={classes.title}>

--- a/services/frontend/src/routes/home/rateCategory.js
+++ b/services/frontend/src/routes/home/rateCategory.js
@@ -38,7 +38,6 @@ const RatingCategory = ({ classes }) => {
       container
       xs={12}
       className={classes.ratingContainer}
-      spacing={24}
     >
       <Grid item xs={12} md={12}>
         <Typography variant='h5' className={classes.title}>

--- a/services/frontend/src/routes/home/subTopic.js
+++ b/services/frontend/src/routes/home/subTopic.js
@@ -29,7 +29,6 @@ const SubTopic = ({ classes }) => {
       container
       xs={12}
       className={classes.subTopicContainer}
-      spacing={24}
     >
       <Grid item xs={12} md={6}>
         <Typography variant='h5' className={classes.title}>

--- a/services/frontend/src/routes/not-found/index.js
+++ b/services/frontend/src/routes/not-found/index.js
@@ -22,7 +22,6 @@ const styles = ({ spacing, palette }) => ({
     background: palette.primary.sectionBackground,
     display: 'flex',
     alignItems: 'center',
-    // justifyContent: 'space-around',
     flexDirection: 'column',
     '& > *': {
       marginTop: spacing(4)
@@ -77,8 +76,7 @@ const NotFound = ({ classes }) => {
 }
 
 NotFound.propTypes = {
-  classes: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired
+  classes: PropTypes.object.isRequired
 }
 
 export default withStyles(styles)(NotFound)

--- a/services/frontend/src/services/bps.js
+++ b/services/frontend/src/services/bps.js
@@ -1,7 +1,10 @@
+import gql from 'graphql-tag'
+import _get from 'lodash.get'
+
 import mockedBPs from 'mock/bps'
 import client from 'services/graphql'
-import gql from 'graphql-tag'
 import getBPRadarData from 'utils/getBPRadarData'
+import calculateEosFromVotes from 'utils/convertVotesToEosVotes'
 
 export const getAllBPs = ({ nameFilter = null, setBPs = () => {} } = {}) => {
   const containsActive = {
@@ -60,11 +63,13 @@ export const getAllBPs = ({ nameFilter = null, setBPs = () => {} } = {}) => {
             transparency: transparency || 0,
             trustiness: trustiness || 0
           }
+          const votesInEos = calculateEosFromVotes(_get(bp, 'system.total_votes', 0))
 
           return {
             ...bp,
             system: {
               ...bp.system,
+              votesInEos,
               parameters
             },
             data: getBPRadarData({

--- a/services/frontend/src/utils/convertVotesToEosVotes.js
+++ b/services/frontend/src/utils/convertVotesToEosVotes.js
@@ -1,0 +1,13 @@
+/**
+ * All this functionality should move into the BE project
+ */
+
+const TIMESTAMP_EPOCH = 946684800
+
+const castToNumber = value => (!isNaN(Number(value)) ? value / 1 : 0)
+
+export default votes => {
+  const date = Date.now() / 1000 - TIMESTAMP_EPOCH
+  const weight = date / (86400 * 7) / 52 // 86400 = seconds per day 24*3600
+  return castToNumber(votes) / 2 ** weight / 10000
+}

--- a/services/frontend/src/utils/formatNumber.js
+++ b/services/frontend/src/utils/formatNumber.js
@@ -1,0 +1,10 @@
+export default (number = 0, precision = 2) => {
+  if (isNaN(number)) return number
+
+  const [integerSection, decimalSection] = parseFloat(number).toFixed(precision).split('.')
+  const integerSectionFormated = integerSection.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
+  if (!decimalSection) return integerSectionFormated
+
+  return `${integerSectionFormated}.${decimalSection}`
+}

--- a/services/update-bps/index.js
+++ b/services/update-bps/index.js
@@ -18,6 +18,8 @@ const getBlockProducersData = async () => {
   const allProducers = producers.reduce((result, producer) => {
     if (!producer.is_active || !parseInt(producer.total_votes)) return result
 
+    console.log(producer.owner, ' TOTAL VOTES: ----> ', producer.total_votes)
+
     return [
       ...result,
       {


### PR DESCRIPTION
### Complete UI task and add several objects validation

#295 Format Votes on BP profile Page
#297 Add links to BPs social media
#294 Add link to BP website
#296 Display BP average rating and number of Votes
#277 Redirect in redux (Query mutation)
#309 Wrong Text in Breadcrumb Navigation

### Steps to test

1. go to EOS RATE
2. click and see all blocks producers list
3. choose one block producer
4. look at all BP profile data (now you can click on the website link and social options links)

Optional Test:
1. use search component (it should be working as expected)
2. type an URL manually and try to access to the profile page of a no existing block producer (e.g. `/block-producers/testnamebp`)

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title to follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact on site performance.
