### PR TITLE
Add hasura actions

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -80,7 +80,7 @@ services:
 
   hasura:
     container_name: eosrate_hasura
-    image: hasura/graphql-engine:v1.1.0.cli-migrations
+    image: hasura/graphql-engine:v1.2.0-beta.1.cli-migrations
     ports:
       - "8088:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
 
   hasura:
     container_name: eosrate_hasura
-    image: hasura/graphql-engine:v1.1.0.cli-migrations
+    image: hasura/graphql-engine:v1.2.0-beta.1.cli-migrations
     ports:
       - "8088:8080"
     depends_on:

--- a/services/hapi/src/index.js
+++ b/services/hapi/src/index.js
@@ -23,18 +23,18 @@ const init = async () => {
   server.route({
     method: 'POST',
     path: '/ratebp',
-    handler: (req, resp) => {
-      const bp = req.payload.producer
+    handler: req => {
+      console.log(req.payload.input.ratingInput)
+      const bp = req.payload.input.ratingInput.producer
       if (bp) {
         updateBpStats(bp)
       }
-      const user = req.payload.user
+      const user = req.payload.input.ratingInput.user
       if (user) {
         updateUserRatings(user)
       }
 
       return {
-        response: resp.payload,
         message: 'updating stats for producer: ' + bp + ' user : ' + user
       }
     }

--- a/services/hapi/src/index.js
+++ b/services/hapi/src/index.js
@@ -21,20 +21,22 @@ const init = async () => {
   })
 
   server.route({
-    method: 'GET',
+    method: 'POST',
     path: '/ratebp',
-    handler: request => {
-      const bp = request.query.producer
+    handler: (req, resp) => {
+      const bp = req.payload.producer
       if (bp) {
         updateBpStats(bp)
       }
-
-      const user = request.query.user
+      const user = req.payload.user
       if (user) {
         updateUserRatings(user)
       }
 
-      return 'updating stats for producer: ' + bp + ' user : ' + user
+      return {
+        response: resp.payload,
+        message: 'updating stats for producer: ' + bp + ' user : ' + user
+      }
     }
   })
 

--- a/services/hasura/migrations/1582950844052_create_action_rateProducer/down.yaml
+++ b/services/hasura/migrations/1582950844052_create_action_rateProducer/down.yaml
@@ -1,0 +1,9 @@
+- args:
+    name: rateProducer
+  type: drop_action
+- args:
+    enums: []
+    input_objects: []
+    objects: []
+    scalars: []
+  type: set_custom_types

--- a/services/hasura/migrations/1582950844052_create_action_rateProducer/up.yaml
+++ b/services/hasura/migrations/1582950844052_create_action_rateProducer/up.yaml
@@ -1,0 +1,35 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: response
+        type: String!
+      name: RatingOutput
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: arg1
+        type: RatingInput!
+      forward_client_headers: false
+      handler: https://hapi:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: create_action

--- a/services/hasura/migrations/1582994080171_modify_action_rateProducer_to_rateProducer/down.yaml
+++ b/services/hasura/migrations/1582994080171_modify_action_rateProducer_to_rateProducer/down.yaml
@@ -1,0 +1,37 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - arguments: null
+        description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: arg1
+        type: RatingInput!
+      forward_client_headers: false
+      handler: https://hapi:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1582994080171_modify_action_rateProducer_to_rateProducer/up.yaml
+++ b/services/hasura/migrations/1582994080171_modify_action_rateProducer_to_rateProducer/up.yaml
@@ -1,0 +1,36 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: https://hapi:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1582994256642_modify_action_rateProducer_to_rateProducer/down.yaml
+++ b/services/hasura/migrations/1582994256642_modify_action_rateProducer_to_rateProducer/down.yaml
@@ -1,0 +1,37 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - arguments: null
+        description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: https://hapi:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1582994256642_modify_action_rateProducer_to_rateProducer/up.yaml
+++ b/services/hasura/migrations/1582994256642_modify_action_rateProducer_to_rateProducer/up.yaml
@@ -1,0 +1,36 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://localhost:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004430995_modify_action_rateProducer_to_rateProducer/down.yaml
+++ b/services/hasura/migrations/1583004430995_modify_action_rateProducer_to_rateProducer/down.yaml
@@ -1,0 +1,37 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - arguments: null
+        description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://localhost:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004430995_modify_action_rateProducer_to_rateProducer/up.yaml
+++ b/services/hasura/migrations/1583004430995_modify_action_rateProducer_to_rateProducer/up.yaml
@@ -1,0 +1,36 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://host.docker.internal:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004453318_modify_action_rateProducer_to_rateProducer/down.yaml
+++ b/services/hasura/migrations/1583004453318_modify_action_rateProducer_to_rateProducer/down.yaml
@@ -1,0 +1,37 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - arguments: null
+        description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://host.docker.internal:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004453318_modify_action_rateProducer_to_rateProducer/up.yaml
+++ b/services/hasura/migrations/1583004453318_modify_action_rateProducer_to_rateProducer/up.yaml
@@ -1,0 +1,36 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://host.docker.internal:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004636939_modify_action_rateProducer_to_rateProducer/down.yaml
+++ b/services/hasura/migrations/1583004636939_modify_action_rateProducer_to_rateProducer/down.yaml
@@ -1,0 +1,37 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - arguments: null
+        description: null
+        name: response
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://host.docker.internal:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action

--- a/services/hasura/migrations/1583004636939_modify_action_rateProducer_to_rateProducer/up.yaml
+++ b/services/hasura/migrations/1583004636939_modify_action_rateProducer_to_rateProducer/up.yaml
@@ -1,0 +1,36 @@
+- args:
+    enums: []
+    input_objects:
+    - description: null
+      fields:
+      - description: null
+        name: user
+        type: String!
+      - description: null
+        name: producer
+        type: String!
+      name: RatingInput
+    objects:
+    - description: null
+      fields:
+      - description: null
+        name: message
+        type: String!
+      name: RatingOutput
+      relationships: null
+    scalars: []
+  type: set_custom_types
+- args:
+    comment: null
+    definition:
+      arguments:
+      - description: null
+        name: ratingInput
+        type: RatingInput!
+      forward_client_headers: false
+      handler: http://host.docker.internal:3005/ratebp
+      headers: []
+      kind: synchronous
+      output_type: RatingOutput
+    name: rateProducer
+  type: update_action


### PR DESCRIPTION
### Add Hasura Actions for Ratings 

This PR exposes a new motation to trigger a hapi endpoint that will update a blockproducer's stats and a user's ratings.

### Steps to test

1. run the following mutation:

```
mutation rateProducer {
  rateProducer(ratingInput: { producer: "junglemorpho", user: "tetogomezeos" }) {
    message
  }
}
```

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
