### PR TITLE
add proxies table and script

### DIFF
--- a/services/hapi/src/libs/sync-proxies.js
+++ b/services/hapi/src/libs/sync-proxies.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+const { JsonRpc } = require('eosjs')
+const EosApi = require('eosjs-api')
+const fetch = require('node-fetch')
+const massive = require('massive')
+
+const dbConfig = require('../config/dbConfig')
+
+const EOS_API_ENDPOINT = process.env.EOS_API_ENDPOINT || 'https://jungle.eosio.cr'
+
+// gets data from blockchain
+const getProxiesData = async () => {
+  const db = await massive(dbConfig)
+  const eos = new JsonRpc(EOS_API_ENDPOINT, { fetch })
+  const eosApi = EosApi({ 
+    httpEndpoint: EOS_API_ENDPOINT, 
+    verbose: false 
+  })
+
+   const  {rows : proxies} = await eos.get_table_rows({
+    json: true,
+    code: 'regproxyinfo',
+    scope: 'regproxyinfo',
+    table: 'proxies',
+    limit: 1000,
+    reverse: false,
+    show_payer: false
+  })
+
+  const getProxyAccount = async (proxy,i) => {
+
+    let account = await eosApi.getAccount({ account_name: proxy.owner })
+    
+    if (account.voter_info.is_proxy) {
+      proxies[i].voter_info = account.voter_info
+      try {
+        const result = await db.proxies.save(proxies[i])
+        if (!result) {
+          const insertResult = await db.proxies.insert(proxies[i])
+          if (!insertResult) {
+            console.log(`couldnt save or insert ${proxies[i].owner}`)
+            return
+          }
+        }
+        console.log(`succefully saved ${proxies[i].owner}`)
+      } catch (error) {
+        console.log('error', error)
+      }
+    } else {
+      //proxies.splice(i, 1)
+      console.log(proxies[i].owner + " is not a proxy") 
+    }
+  }
+
+  proxies.forEach(getProxyAccount)
+  return proxies
+}
+
+
+getProxiesData()
+

--- a/services/hasura/migrations/1584293813117_create_table_public_proxies/down.yaml
+++ b/services/hasura/migrations/1584293813117_create_table_public_proxies/down.yaml
@@ -1,0 +1,5 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: DROP TABLE "public"."proxies";
+  type: run_sql

--- a/services/hasura/migrations/1584293813117_create_table_public_proxies/up.yaml
+++ b/services/hasura/migrations/1584293813117_create_table_public_proxies/up.yaml
@@ -1,0 +1,12 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: CREATE TABLE "public"."proxies"("owner" text NOT NULL, "name" text NOT NULL,
+      "website" text, "slogan" text, "philosophy" text, "background" text, "logo_256"
+      text, "telegram" text, "steemit" text, "twitter" text, "wechat" text, "voter_info"
+      jsonb NOT NULL, PRIMARY KEY ("owner") , UNIQUE ("owner"), UNIQUE ("name"));
+  type: run_sql
+- args:
+    name: proxies
+    schema: public
+  type: add_existing_table_or_view


### PR DESCRIPTION
### GH Issue

 #343 Save info on registered proxies

### Steps to test

1. Run `node /services/hapi/src/libs/sync-proxies.js`
2. fetch data from the table: `proxies`
