### PR TITLE
 Clear ratings for inactive producers

### DIFF
--- a/contracts/rateproducer/README.md
+++ b/contracts/rateproducer/README.md
@@ -15,16 +15,19 @@ Push rating with partial categories:
 cleos -u http://monitor.jungletestnet.io:8888 push action rateproducer rate '{ "user": "rateproducer", "bp":"alohaeostest","transparency":8,"infrastructure":0,"trustiness":0,"development":0,"community":0 }' -p rateproducer@active
 
 Get stats table:
-Cleos -u http://jungle2.cryptolions.io:80 get table rateproducer rateproducer stats
+cleos -u http://jungle2.cryptolions.io:80 get table -l 50 rateproducer rateproducer stats
 
 Get bp table:
-Cleos -u http://jungle2.cryptolions.io:80 get table rateproducer rateproducer ratings
+cleos -u http://jungle2.cryptolions.io:80 get table -l 50 rateproducer rateproducer ratings
 
 Clean data for a block producer :
 cleos -u http://monitor.jungletestnet.io:8888 push action rateproducer erase '{"bp_name":"eoscrprodo55"}' -p rateproducer@active
 
 Clean all tables:
 cleos -u http://monitor.jungletestnet.io:8888 push action rateproducer wipe '[]' -p rateproducer@active
+
+Clean data from un-register/inactive bp
+cleos -u http://monitor.jungletestnet.io:8888 push action rateproducer rminactive '[]' -p rateproducer@active
 
 ```
 Run test
@@ -36,5 +39,6 @@ you need to assign the priv key for the variable ```rateproducer_priv_key``` wit
  yarn install
  yarn test
  yarn test_average
+ yarn test_unreg_bp
 ```
 

--- a/contracts/tests/package.json
+++ b/contracts/tests/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "scripts": {
     "test": "mocha --timeout 180000 test.js",
-    "test_average": "mocha --timeout 180000 test_average.js"  
+    "test_average": "mocha --timeout 180000 test_average.js",  
+    "test_unreg_bp": "mocha --timeout 180000 test_unreg_bp.js"  
   },
   "dependencies": {
     "chai": "^4.2.0",

--- a/contracts/tests/test.js
+++ b/contracts/tests/test.js
@@ -7,7 +7,7 @@ const contract_acct="rateproducer";
 const proxy_acc='eoscrprox111';
 const voter_acc='eoscrvoter11';
 
-const rateproducer_priv_key='5HrYs51N1Psq....2sjA5LeQjJ9gUqN';
+const rateproducer_priv_key='5HrYs51N1Psq...m2sjA5LeQjJ9gUqN';
 const rateproducer_pub_key='EOS7Ca5Tc4KaEYLZdu2WxdQQktVePjFiDg42EmMAjqVR6eNKPMrAA';
 const MIN_VAL = 0;
 const MAX_VAL = 10;

--- a/contracts/tests/test_average.js
+++ b/contracts/tests/test_average.js
@@ -5,7 +5,7 @@ const { TextEncoder, TextDecoder } = require('util');                   // node 
 
 const contract_acct="rateproducer";
 
-const rateproducer_priv_key='5HrYs51N1Psq ....TKSRTm2sjA5LeQjJ9gUqN';
+const rateproducer_priv_key='5HrYs51N1Psq...m2sjA5LeQjJ9gUqN';
 const rateproducer_pub_key='EOS7Ca5Tc4KaEYLZdu2WxdQQktVePjFiDg42EmMAjqVR6eNKPMrAA';
 const MIN_VAL = 0;
 const MAX_VAL = 10;

--- a/contracts/tests/test_unreg_bp.js
+++ b/contracts/tests/test_unreg_bp.js
@@ -1,0 +1,426 @@
+const { Api, JsonRpc, RpcError } = require('eosjs');
+const { JsSignatureProvider } = require('eosjs/dist/eosjs-jssig');      // development only
+const fetch = require('node-fetch');                                    // node only; not needed in browsers
+const { TextEncoder, TextDecoder } = require('util');                   // node only; native TextEncoder/Decoder
+
+const contract_acct="rateproducer";
+const proxy_acc='eoscrprox111';
+const voter_acc='eoscrvoter11';
+
+const rateproducer_priv_key='5HrYs51N1Psq...m2sjA5LeQjJ9gUqN';
+const rateproducer_pub_key='EOS7Ca5Tc4KaEYLZdu2WxdQQktVePjFiDg42EmMAjqVR6eNKPMrAA';
+const MIN_VAL = 0;
+const MAX_VAL = 10;
+
+const signatureProvider = new JsSignatureProvider([rateproducer_priv_key]);
+const rpc = new JsonRpc('http://monitor.jungletestnet.io:8888', { fetch });
+const api = new Api({ rpc, signatureProvider, textDecoder: new TextDecoder(), textEncoder: new TextEncoder() });
+const get = require('lodash.get')
+var chai = require('chai'),assert = chai.assert;
+
+
+var bp_accts_25 = [
+                "eoscrprodo11","eoscrprodo12","eoscrprodo13","eoscrprodo14","eoscrprodo15",
+                "eoscrprodo21","eoscrprodo22","eoscrprodo23","eoscrprodo24","eoscrprodo25",
+                "eoscrprodo31","eoscrprodo32","eoscrprodo33","eoscrprodo34","eoscrprodo35",
+                "eoscrprodo41","eoscrprodo42","eoscrprodo43","eoscrprodo44","eoscrprodo45",
+                "eoscrprodo51","eoscrprodo52","eoscrprodo53","eoscrprodo54","eoscrprodo55"
+                 ];
+
+var bp_accts_21 = [
+                "eoscrprodo11","eoscrprodo12","eoscrprodo13","eoscrprodo14","eoscrprodo15",
+                "eoscrprodo21","eoscrprodo22","eoscrprodo23","eoscrprodo24","eoscrprodo25",
+                "eoscrprodo31","eoscrprodo32","eoscrprodo33","eoscrprodo34","eoscrprodo35",
+                "eoscrprodo41","eoscrprodo42","eoscrprodo43","eoscrprodo44","eoscrprodo45",
+                "eoscrprodo51"
+                 ];
+
+
+describe ('Eos-rate unit test', function(){
+    
+    
+    
+    it('Register accounts as block producers',async () => {
+
+    for(index =0 ; index < bp_accts_25.length; index++ ){  
+      try {
+          const result = await api.transact({
+              actions: [{
+                account: 'eosio',
+                name: 'regproducer',
+                authorization: [{
+                  actor: bp_accts_25[index],
+                  permission: 'active',
+                }],
+                data: {
+                  producer: bp_accts_25[index],
+                  producer_key : rateproducer_pub_key,
+                  url:'https://eoscostarica.io',
+                  location:'0',
+                },
+              }]
+            }, {
+              blocksBehind: 3,
+              expireSeconds: 30,
+            });
+        } catch (err) {
+          console.log('\nCaught exception: ' + err);
+          if (err instanceof RpcError)
+            console.log(JSON.stringify(err.json, null, 2));
+        }
+    }
+    });
+    
+
+    
+    it('Set up 21 voters for ' + voter_acc + ' account',async () => {
+      try {
+          const result = await api.transact({
+              actions: [{
+                account: 'eosio',
+                name: 'voteproducer',
+                authorization: [{
+                  actor: voter_acc,
+                  permission: 'active',
+                }],
+                data: {
+                  voter: voter_acc,
+                  proxy: '',
+                  producers: bp_accts_21,
+                },
+              }]
+            }, {
+              blocksBehind: 3,
+              expireSeconds: 30,
+            });
+        } catch (err) {
+         console.log('\nCaught exception: ' + err);
+          if (err instanceof RpcError)
+            console.log(JSON.stringify(err.json, null, 2));
+        }
+    });
+
+    
+    it("Removing previous inactive bp data",async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rminactive',
+                  authorization: [{
+                    actor: contract_acct,
+                    permission: 'active',
+                  }],
+                  data: {                   
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+              
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it("Test zero inactive bp ",async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rminactive',
+                  authorization: [{
+                    actor: contract_acct,
+                    permission: 'active',
+                  }],
+                  data: {                   
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+              var action_echo =result["processed"]["action_traces"][0]["console"];
+              var pos = action_echo.indexOf(":");
+              assert(pos>0, 'error within bps deleted:  tag ');
+              var num_bps = action_echo.substring(pos+1);
+              assert(num_bps==0, ' Error expected zero as returned value');
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it(voter_acc + ' rating for ' + bp_accts_25[0],async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rate',
+                  authorization: [{
+                    actor: voter_acc,
+                    permission: 'active',
+                  }],
+                  data: {
+                    user: voter_acc,
+                    bp: bp_accts_25[0],
+                    transparency:8,
+                    infrastructure:8,
+                    trustiness:7,
+                    development:6,
+                    community:9,
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it('Unregister bp ' + bp_accts_25[0],async () => {
+
+        
+          try {
+              const result = await api.transact({
+                  actions: [{
+                    account: 'eosio',
+                    name: 'unregprod',
+                    authorization: [{
+                      actor: bp_accts_25[0],
+                      permission: 'active',
+                    }],
+                    data: {
+                      producer: bp_accts_25[0],
+                    },
+                  }]
+                }, {
+                  blocksBehind: 3,
+                  expireSeconds: 30,
+                });
+            } catch (err) {
+             console.log('\nCaught exception: ' + err);
+              if (err instanceof RpcError)
+                console.log(JSON.stringify(err.json, null, 2));
+            }
+        
+    });
+    
+    it("Test one inactive bp ",async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rminactive',
+                  authorization: [{
+                    actor: contract_acct,
+                    permission: 'active',
+                  }],
+                  data: {                   
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+              var action_echo =result["processed"]["action_traces"][0]["console"];
+              var pos = action_echo.indexOf(":");
+              assert(pos>0, 'error within bps deleted:  tag ');
+              var num_bps = action_echo.substring(pos+1);
+              assert(num_bps==1, ' Error expected 1 as returned value');
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it(voter_acc + ' rating for ' + bp_accts_25[1],async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rate',
+                  authorization: [{
+                    actor: voter_acc,
+                    permission: 'active',
+                  }],
+                  data: {
+                    user: voter_acc,
+                    bp: bp_accts_25[1],
+                    transparency:8,
+                    infrastructure:8,
+                    trustiness:7,
+                    development:6,
+                    community:9,
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it(voter_acc + ' rating for ' + bp_accts_25[2],async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rate',
+                  authorization: [{
+                    actor: voter_acc,
+                    permission: 'active',
+                  }],
+                  data: {
+                    user: voter_acc,
+                    bp: bp_accts_25[2],
+                    transparency:8,
+                    infrastructure:8,
+                    trustiness:7,
+                    development:6,
+                    community:9,
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    it('Unregister bp ' + bp_accts_25[1],async () => {
+
+        
+          try {
+              const result = await api.transact({
+                  actions: [{
+                    account: 'eosio',
+                    name: 'unregprod',
+                    authorization: [{
+                      actor: bp_accts_25[1],
+                      permission: 'active',
+                    }],
+                    data: {
+                      producer: bp_accts_25[1],
+                    },
+                  }]
+                }, {
+                  blocksBehind: 3,
+                  expireSeconds: 30,
+                });
+            } catch (err) {
+             console.log('\nCaught exception: ' + err);
+              if (err instanceof RpcError)
+                console.log(JSON.stringify(err.json, null, 2));
+            }
+        
+    });
+    
+    it('Unregister bp ' + bp_accts_25[2],async () => {
+
+        
+          try {
+              const result = await api.transact({
+                  actions: [{
+                    account: 'eosio',
+                    name: 'unregprod',
+                    authorization: [{
+                      actor: bp_accts_25[2],
+                      permission: 'active',
+                    }],
+                    data: {
+                      producer: bp_accts_25[2],
+                    },
+                  }]
+                }, {
+                  blocksBehind: 3,
+                  expireSeconds: 30,
+                });
+            } catch (err) {
+             console.log('\nCaught exception: ' + err);
+              if (err instanceof RpcError)
+                console.log(JSON.stringify(err.json, null, 2));
+            }
+        
+    });
+    
+    it("Test two inactive bp ",async () => {
+        try {
+            const result = await api.transact({
+                actions: [{
+                  account: contract_acct,
+                  name: 'rminactive',
+                  authorization: [{
+                    actor: contract_acct,
+                    permission: 'active',
+                  }],
+                  data: {                   
+                  },
+                }]
+              }, {
+                blocksBehind: 3,
+                expireSeconds: 30,
+              });
+              var action_echo =result["processed"]["action_traces"][0]["console"];
+              var pos = action_echo.indexOf(":");
+              assert(pos>0, 'error within bps deleted:  tag ');
+              var num_bps = action_echo.substring(pos+1);
+              assert(num_bps==2, ' Error expected 2 as returned value');
+          } catch (err) {
+             console.log('\nCaught exception: ' + err);
+             if (err instanceof RpcError)
+             console.log(JSON.stringify(err.json, null, 2));
+          }
+    });
+    
+    
+
+ 
+
+    it('Unregister producers accounts',async () => {
+
+    for(index =0 ; index < bp_accts_25.length; index++ ){  
+      try {
+          const result = await api.transact({
+              actions: [{
+                account: 'eosio',
+                name: 'unregprod',
+                authorization: [{
+                  actor: bp_accts_25[index],
+                  permission: 'active',
+                }],
+                data: {
+                  producer: bp_accts_25[index],
+                },
+              }]
+            }, {
+              blocksBehind: 3,
+              expireSeconds: 30,
+            });
+        } catch (err) {
+         console.log('\nCaught exception: ' + err);
+          if (err instanceof RpcError)
+            console.log(JSON.stringify(err.json, null, 2));
+        }
+    }
+    });
+
+ 
+});


### PR DESCRIPTION
### 
Clear ratings for inactive producers
this fix the issue #300  
When a bp become inactive, the contract still storage the votes related to inactive bp
theres a new action `rminactive` which can periodic check and clean the dirty data


### Steps to test
`cleos -u http://monitor.jungletestnet.io:8888 push action rateproducer rminactive '[]' -p rateproducer@active`

### Unit test suite

1. go inside tests folder
2. you need to assign the priv key for the variable ```rateproducer_priv_key``` within the file  test_unreg_bp.js
3. execute
 ```
 yarn add eosjs
 yarn install
 yarn test_unreg_bp
```
 

