### PR TITLE
improvement: add kubernetes deployment and service files

### DIFF
--- a/kubernetes/demux-deployment.yaml
+++ b/kubernetes/demux-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: demux
+  name: demux
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: demux
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.network/default: "true"
+        io.kompose.service: demux
+    spec:
+      containers:
+      - env:
+        - name: DB_HOST
+          value: postgres
+        - name: DB_NAME
+          value: eosrate
+        - name: DB_PASSWORD
+          value: pass
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_SCHEMA
+          value: public
+        - name: DB_USER
+          value: user
+        - name: EOS_API_ENDPOINT
+          value: https://jungle.eosio.cr
+        - name: WAIT_HOSTS
+          value: postgres:5432, hasura:8088
+        - name: WAIT_HOSTS_TIMEOUT
+          value: "60"
+        image: eosrate/demux
+        imagePullPolicy: "Never"
+        name: eosrate-demux
+        ports:
+        - containerPort: 3030
+        volumeMounts:
+        - mountPath: /opt/application
+          name: demux1
+        - mountPath: /opt/application/node_modules
+          name: demux2
+      restartPolicy: Always
+      volumes:
+      - name: demux1
+        hostPath:
+          path: /opt/eos-rate/services/demux
+          type: Directory
+      - name: demux2
+        hostPath:
+          path: /mnt
+          type: Directory

--- a/kubernetes/demux-service.yaml
+++ b/kubernetes/demux-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: demux
+  name: demux
+spec:
+  ports:
+  - name: "3030"
+    port: 3030
+    targetPort: 3030
+  selector:
+    io.kompose.service: demux

--- a/kubernetes/frontend-deployment.yaml
+++ b/kubernetes/frontend-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend
+  template:
+    metadata:
+      labels:
+        io.kompose.network/default: "true"
+        io.kompose.service: frontend
+    spec:
+      containers:
+      - image: eosrate/frontend
+        imagePullPolicy: "Never"
+        name: eosrate-frontend
+        env:
+        - name: REACT_APP_GRAPHQL_HTTP_URL
+          value: http://hasura:8088/v1alpha1/graphql
+        - name: REACT_APP_GRAPHQL_WS_URL
+          value: ws://hasura:8088/v1alpha1/graphql
+        ports:
+        - containerPort: 80
+      restartPolicy: Always

--- a/kubernetes/frontend-service.yaml
+++ b/kubernetes/frontend-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: frontend
+  name: frontend
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  selector:
+    io.kompose.service: frontend

--- a/kubernetes/hapi-deployment.yaml
+++ b/kubernetes/hapi-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: hapi
+  name: hapi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: hapi
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.network: "true"
+        io.kompose.service: hapi
+    spec:
+      containers:
+      - env:
+        - name: DB_HOST
+          value: postgres
+        - name: DB_NAME
+          value: eosrate
+        - name: DB_PASSWORD
+          value: pass
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_SCHEMA
+          value: public
+        - name: DB_USER
+          value: user
+        - name: EOS_API_ENDPOINT
+          value: https://jungle.eosio.cr
+        - name: VIRTUAL_HOST
+          value: 0.0.0.0
+        - name: VIRTUAL_PORT
+          value: "3005"
+        image: hapi
+        imagePullPolicy: "Never"
+        name: eosrate-hapi
+        ports:
+        - containerPort: 3005
+        volumeMounts:
+        - mountPath: /opt/application
+          name: hapi1
+        - mountPath: /opt/application/node_modules
+          name: hapi2
+      restartPolicy: Always
+      volumes:
+      - name: hapi1
+        hostPath:
+          path: /opt/eos-rate/services/hapi
+          type: Directory
+      - name: hapi2
+        hostPath:
+          path: /mnt
+          type: Directory

--- a/kubernetes/hapi-service.yaml
+++ b/kubernetes/hapi-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: hapi
+  name: hapi
+spec:
+  ports:
+  - name: "3005"
+    port: 3005
+    targetPort: 3005
+  selector:
+    io.kompose.service: hapi

--- a/kubernetes/hasura-deployment.yaml
+++ b/kubernetes/hasura-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: hasura
+  name: hasura
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: hasura
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.network: "true"
+        io.kompose.service: hasura
+    spec:
+      containers:
+      - args:
+        - graphql-engine
+        - serve
+        - --enable-console
+        env:
+        - name: HASURA_GRAPHQL_DATABASE_URL
+          value: postgres://user:pass@postgres:5432/eosrate?sslmode=disable
+        - name: HASURA_GRAPHQL_MIGRATIONS_DIR
+          value: /hasura-migrations
+        image: hasura/graphql-engine:v1.2.0-beta.2.cli-migrations
+        imagePullPolicy: ""
+        name: eosrate-hasura
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - mountPath: /hasura-migrations
+          name: hasura1
+      restartPolicy: Always
+      volumes:
+      - name: hasura1
+        hostPath:
+          path: /mnt

--- a/kubernetes/hasura-service.yaml
+++ b/kubernetes/hasura-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: hasura
+  name: hasura
+spec:
+  ports:
+  - name: "8088"
+    port: 8088
+    targetPort: 8080
+  selector:
+    io.kompose.service: hasura

--- a/kubernetes/networkpolicy.yaml
+++ b/kubernetes/networkpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          io.kompose.network/default: "true"
+  podSelector:
+    matchLabels:
+      io.kompose.network/default: "true"

--- a/kubernetes/pgweb-deployment.yaml
+++ b/kubernetes/pgweb-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: pgweb
+  name: pgweb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: pgweb
+  template:
+    metadata:
+      labels:
+        io.kompose.network: "true"
+        io.kompose.service: pgweb
+    spec:
+      containers:
+      - env:
+        - name: DATABASE_URL
+          value: postgres://user:pass@postgres:5432/eosrate?sslmode=disable
+        image: sosedoff/pgweb:latest
+        imagePullPolicy: ""
+        name: eosrate-pgweb
+        ports:
+        - containerPort: 8081
+      restartPolicy: Always

--- a/kubernetes/pgweb-service.yaml
+++ b/kubernetes/pgweb-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: pgweb
+  name: pgweb
+spec:
+  ports:
+  - name: "8082"
+    port: 8082
+    targetPort: 8081
+  selector:
+    io.kompose.service: pgweb

--- a/kubernetes/postgres-deployment.yaml
+++ b/kubernetes/postgres-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.network: "true"
+        io.kompose.service: postgres
+    spec:
+      containers:
+      - env:
+        - name: DB_NAME
+          value: eosrate
+        - name: DB_PASSWORD
+          value: pass
+        - name: DB_USER
+          value: user
+        - name: POSTGRES_DB
+          value: eosrate
+        - name: POSTGRES_PASSWORD
+          value: pass
+        - name: POSTGRES_USER
+          value: user
+        image: postgres:10.4
+        imagePullPolicy: ""
+        name: eosrate-postgres
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: eosrate-postgres
+      restartPolicy: Always
+      volumes:
+      - name: eosrate-postgres
+        hostPath:
+          path: /mnt
+          type: Directory

--- a/kubernetes/postgres-service.yaml
+++ b/kubernetes/postgres-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    targetPort: 5432
+  selector:
+    io.kompose.service: postgres


### PR DESCRIPTION
uses kubernetes to deploy EOS-rate in a k8s cluster.
Still TODO:

* Allocate dynamic storage instead of a local directory for
  volumes.
* Allocate dynamic external IPs for exposing services.

refs #224 and #https://github.com/edenia/openstack-docs/issues/18.
depends on the frontend container created in #366.

### GH Issue

# Deploy EOS-rate in a k8s cluster.

### Steps to test

1. kubectl create -f kubernetes/
1. kubectl port-forward service/frontend 80:80
1. visit {external_ip}
1. you should see the eos rate page

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
