### PR TITLE
refactor(FE): hide or show sort option

### DIFF
--- a/services/frontend/src/components/app-bar.js
+++ b/services/frontend/src/components/app-bar.js
@@ -106,7 +106,9 @@ const MainTopBar = ({
   ual,
   getUserChainData,
   setUser,
-  setSortBy
+  setSortBy,
+  showSortSelected,
+  setShowSortSelected
 }) => {
   const { t } = useTranslation('translations')
 
@@ -119,6 +121,12 @@ const MainTopBar = ({
 
     getData()
   }, [ual.loading])
+
+  useEffect(() => {
+    if (window.location.pathname !== '/block-producers' && showSortSelected) {
+      setShowSortSelected(false)
+    }
+  })
 
   return (
     <AppBar position='absolute'>
@@ -147,7 +155,7 @@ const MainTopBar = ({
         >
           <SearchIcon />
         </IconButton>
-        <FilterSelect onHandleApplySortBy={setSortBy} />
+        {showSortSelected && <FilterSelect onHandleApplySortBy={setSortBy} />}
         <LanguageSelect />
         {ual.activeUser ? (
           <>
@@ -203,13 +211,20 @@ MainTopBar.propTypes = {
   ual: PropTypes.object,
   getUserChainData: PropTypes.func,
   setUser: PropTypes.func,
-  setSortBy: PropTypes.func
+  setSortBy: PropTypes.func,
+  showSortSelected: PropTypes.bool,
+  setShowSortSelected: PropTypes.func
 }
+
+const mapStatetoProps = ({ blockProducers }) => ({
+  showSortSelected: blockProducers.showSortSelected
+})
 
 const mapDispatchToProps = ({ user, blockProducers }) => ({
   getUserChainData: user.getUserChainData,
   setUser: user.removeBlockProducersVotedByUser,
-  setSortBy: blockProducers.setSortBy
+  setSortBy: blockProducers.setSortBy,
+  setShowSortSelected: blockProducers.setShowSortSelected
 })
 
-export default withStyles(styles)(connect(null, mapDispatchToProps)(MainTopBar))
+export default withStyles(styles)(connect(mapStatetoProps, mapDispatchToProps)(MainTopBar))

--- a/services/frontend/src/models/BlockProducer/blockProducers.js
+++ b/services/frontend/src/models/BlockProducer/blockProducers.js
@@ -17,7 +17,8 @@ const initialState = {
   selected: [],
   compareTool: true,
   producer: null,
-  userRate: null
+  userRate: null,
+  showSortSelected: false
 }
 
 const Proxies = {
@@ -27,6 +28,12 @@ const Proxies = {
       return {
         ...state,
         compareTool: !state.compareTool
+      }
+    },
+    setShowSortSelected (state, showSortSelected) {
+      return {
+        ...state,
+        showSortSelected
       }
     },
     setBPs (state, list) {

--- a/services/frontend/src/routes/block-producers/block-producer-profile.js
+++ b/services/frontend/src/routes/block-producers/block-producer-profile.js
@@ -147,6 +147,7 @@ const BlockProducerProfile = ({
   getBlockProducer,
   producer,
   isContentLoading,
+  setShowSortSelected,
   ...props
 }) => {
   const { t } = useTranslation('profile')
@@ -165,6 +166,10 @@ const BlockProducerProfile = ({
   useEffect(() => {
     getBlockProducer(account)
   }, [account])
+
+  useEffect(() => {
+    setShowSortSelected(false)
+  })
 
   return (
     <Grid container justify='center' className={classes.container}>
@@ -280,7 +285,8 @@ BlockProducerProfile.propTypes = {
   blockProducers: PropTypes.array,
   getBlockProducer: PropTypes.func,
   producer: PropTypes.object,
-  isContentLoading: PropTypes.bool
+  isContentLoading: PropTypes.bool,
+  setShowSortSelected: PropTypes.func
 }
 
 ProfileTitle.propTypes = {
@@ -301,8 +307,9 @@ const mapStateToProps = ({
   isContentLoading
 })
 
-const mapDispatchToProps = dispatch => ({
-  getBlockProducer: dispatch.blockProducers.getBlockProducerByOwner
+const mapDispatchToProps = ({ blockProducers }) => ({
+  getBlockProducer: blockProducers.getBlockProducerByOwner,
+  setShowSortSelected: blockProducers.setShowSortSelected
 })
 
 export default withStyles(style)(

--- a/services/frontend/src/routes/block-producers/block-producer-rate.js
+++ b/services/frontend/src/routes/block-producers/block-producer-rate.js
@@ -95,7 +95,8 @@ const BlockProducerRate = ({
   addUserRating,
   userRate,
   getBlockProducer,
-  ual
+  ual,
+  setShowSortSelected
 }) => {
   const [ratingState, setRatingState] = useState(INIT_RATING_STATE_DATA)
   const [showMessage, setShowMessage] = useState(false)
@@ -128,6 +129,10 @@ const BlockProducerRate = ({
       setRatingState(INIT_RATING_STATE_DATA)
     }
   }, [userRate])
+
+  useEffect(() => {
+    setShowSortSelected(false)
+  })
 
   const getRatingData = (useString = false) => {
     const {
@@ -427,7 +432,8 @@ BlockProducerRate.propTypes = {
   addUserRating: PropTypes.func,
   userRate: PropTypes.object,
   getBlockProducer: PropTypes.func,
-  ual: PropTypes.object
+  ual: PropTypes.object,
+  setShowSortSelected: PropTypes.func
 }
 
 const mapStateToProps = ({ blockProducers: { producer, userRate } }) => ({
@@ -435,10 +441,11 @@ const mapStateToProps = ({ blockProducers: { producer, userRate } }) => ({
   userRate
 })
 
-const mapDispatchToProps = dispatch => ({
-  getBPRating: dispatch.blockProducers.getBlockProducerRatingByOwner,
-  addUserRating: dispatch.blockProducers.mutationInsertUserRating,
-  getBlockProducer: dispatch.blockProducers.getBlockProducerByOwner
+const mapDispatchToProps = ({ blockProducers }) => ({
+  getBPRating: blockProducers.getBlockProducerRatingByOwner,
+  addUserRating: blockProducers.mutationInsertUserRating,
+  getBlockProducer: blockProducers.getBlockProducerByOwner,
+  setShowSortSelected: blockProducers.setShowSortSelected
 })
 
 export default withStyles(style)(

--- a/services/frontend/src/routes/block-producers/index.js
+++ b/services/frontend/src/routes/block-producers/index.js
@@ -78,7 +78,8 @@ const AllBps = ({
   getUserChainData,
   user,
   storeIsContentLoading,
-  sortBy
+  sortBy,
+  setShowSortSelected
 }) => {
   const { t } = useTranslation('translations')
   const [currentlyVisible, setCurrentlyVisible] = useState(30)
@@ -168,6 +169,7 @@ const AllBps = ({
       }
     }
 
+    setShowSortSelected(true)
     getUserData()
   })
 
@@ -245,7 +247,8 @@ AllBps.propTypes = {
   getUserChainData: PropTypes.func,
   user: PropTypes.object,
   storeIsContentLoading: PropTypes.func,
-  sortBy: PropTypes.string
+  sortBy: PropTypes.string,
+  setShowSortSelected: PropTypes.func
 }
 
 AllBps.defaultProps = {
@@ -263,7 +266,7 @@ const mapStatetoProps = ({ blockProducers, user }) => ({
 })
 
 const mapDispatchToProps = ({
-  blockProducers: { getBPs, toggleCompareTool, addToSelected, removeSelected },
+  blockProducers: { getBPs, toggleCompareTool, addToSelected, removeSelected, setShowSortSelected },
   user: { getUserChainData },
   isLoading: { storeIsContentLoading }
 }) => ({
@@ -272,7 +275,8 @@ const mapDispatchToProps = ({
   addToSelected,
   removeSelected,
   getUserChainData,
-  storeIsContentLoading
+  storeIsContentLoading,
+  setShowSortSelected
 })
 
 export default withStyles(style)(

--- a/services/frontend/src/routes/home/index.js
+++ b/services/frontend/src/routes/home/index.js
@@ -26,12 +26,16 @@ const styles = ({ spacing, palette }) => ({
   }
 })
 
-const Home = ({ classes, home, getBlockData }) => {
+const Home = ({ classes, home, getBlockData, setShowSortSelected, showSortSelected }) => {
   const { t } = useTranslation('home')
 
   useEffect(() => {
     getBlockData()
   }, [])
+
+  useEffect(() => {
+    setShowSortSelected(false)
+  })
 
   return (
     <>
@@ -81,18 +85,22 @@ const Home = ({ classes, home, getBlockData }) => {
   )
 }
 
-const mapStatetoProps = ({ home }) => ({
-  home
+const mapStatetoProps = ({ home, blockProducers }) => ({
+  home,
+  showSortSelected: blockProducers.showSortSelected
 })
 
-const mapDispatchToProps = ({ home: { getBlockData } }) => ({
-  getBlockData
+const mapDispatchToProps = ({ home: { getBlockData }, blockProducers: { setShowSortSelected } }) => ({
+  getBlockData,
+  setShowSortSelected
 })
 
 Home.propTypes = {
   classes: PropTypes.object.isRequired,
   home: PropTypes.object.isRequired,
-  getBlockData: PropTypes.func.isRequired
+  getBlockData: PropTypes.func.isRequired,
+  showSortSelected: PropTypes.bool,
+  setShowSortSelected: PropTypes.func
 }
 
 export default withStyles(styles)(

--- a/services/frontend/src/routes/proxies/index.js
+++ b/services/frontend/src/routes/proxies/index.js
@@ -76,7 +76,8 @@ const AllProxies = ({
   proxies,
   getUserChainData,
   user,
-  ual
+  ual,
+  setShowSortSelected
 }) => {
   const { t } = useTranslation('translations')
   const [currentlyVisible, setCurrentlyVisible] = useState(30)
@@ -102,6 +103,7 @@ const AllProxies = ({
       }
     }
 
+    setShowSortSelected(false)
     getUserData()
   })
 
@@ -177,7 +179,8 @@ AllProxies.propTypes = {
   proxies: PropTypes.array,
   getUserChainData: PropTypes.func,
   user: PropTypes.object,
-  ual: PropTypes.object
+  ual: PropTypes.object,
+  setShowSortSelected: PropTypes.func
 }
 
 AllProxies.defaultProps = {
@@ -196,7 +199,7 @@ const mapStatetoProps = ({ proxies, user }) => ({
 })
 
 const mapDispatchToProps = ({ blockProducers, proxies, user }) => {
-  const { getBPs } = blockProducers
+  const { getBPs, setShowSortSelected } = blockProducers
   const {
     getProxies,
     toggleCompareTool,
@@ -211,7 +214,8 @@ const mapDispatchToProps = ({ blockProducers, proxies, user }) => {
     addToSelected,
     removeSelected,
     getProxies,
-    getUserChainData
+    getUserChainData,
+    setShowSortSelected
   }
 }
 


### PR DESCRIPTION
### GH Issue

# Show Sort options only BPs list page

### Steps to test

1. go to EOS RATE web app (sort options shouldn't be shown)
2. go to BPs list (see Sort options)

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
