### PR TITLE
add stop script

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,9 @@ dev: scripts/develop.sh
 start: scripts/start.sh
 	./scripts/start.sh
 
+stop: scripts/stop.sh
+	./scripts/stop.sh
+
 flush: scripts/flush.sh
 	./scripts/flush.sh
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Stopping all eos-rate services.."
+
+docker-compose down


### PR DESCRIPTION
### Stops docker services 

### Steps to test

1. run `make start`
1. run `make stop`
1. docker services should no longer be running locally


