### PR TITLE
chore: add hasura admin secret configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,9 +87,9 @@ services:
       - postgres
     restart: always
     environment:
-      HASURA_ADMIN_SECRET:
       HASURA_GRAPHQL_DATABASE_URL: postgres://user:pass@postgres:5432/eosrate?sslmode=disable
       HASURA_GRAPHQL_MIGRATIONS_DIR: /hasura-migrations
+      HASURA_GRAPHQL_ADMIN_SECRET: "${HASURA_GRAPHQL_ADMIN_SECRET}"
     volumes:
       - ./services/hasura/migrations:/hasura-migrations #  mount hasura migrations folder
     command:

--- a/kubernetes/hasura-deployment.yaml
+++ b/kubernetes/hasura-deployment.yaml
@@ -27,6 +27,8 @@ spec:
           value: postgres://user:pass@postgres:5432/eosrate?sslmode=disable
         - name: HASURA_GRAPHQL_MIGRATIONS_DIR
           value: /hasura-migrations
+        - name: HASURA_GRAPHQL_ADMIN_SECRET
+          value: ${HASURA_GRAPHQL_ADMIN_SECRET}
         image: hasura/graphql-engine:v1.2.0-beta.2.cli-migrations
         imagePullPolicy: ""
         name: eosrate-hasura


### PR DESCRIPTION
### GH Issue

Secure GraphQL endpoint #317

### Steps to test

1. setup an HASURA_GRAPHQL_ADMIN_SECRET environment variable
2. run `docker-compose -up -d`
3. run `hasura console --endpoint http://localhost:8088 --admin-secret $HASURA_GRAPHQL_ADMIN_SECRET `

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
