### PR TITLE
Cron job hapi

### DIFF
--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -15,4 +15,31 @@ spec:
             - /bin/sh
             - -c
             - /usr/bin/node /opt/application/src/libs/sync-bps.js; /usr/bin/node /opt/application/src/libs/sync-proxies.js
+            env:
+            - name: DB_HOST
+              value: postgres
+            - name: DB_NAME
+              value: eosrate
+            - name: DB_PASSWORD
+              value: pass
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_SCHEMA
+              value: public
+            - name: DB_USER
+              value: user
+            - name: EOS_API_ENDPOINT
+              value: https://bp.cryptolions.io
+            - name: VIRTUAL_HOST
+              value: 0.0.0.0
+            - name: VIRTUAL_PORT
+              value: "3005"
+            volumeMounts:
+            - mountPath: /opt/application
+              name: hapi1
           restartPolicy: Never
+          volumes:
+          - name: hapi1
+            nfs:
+              server: NFS-server
+              path: /home/ubuntu/production/eos-rate/services/hapi

--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hapi-cronjob
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hapi-cronjob
+            image: eoscostarica506/hapi
+            args:
+            - /bin/sh
+            - -c
+            - /usr/bin/node /opt/application/src/libs/sync-bps.js; /usr/bin/node /opt/application/src/libs/sync-proxies.js
+          restartPolicy: Never


### PR DESCRIPTION
### GH Issue

# Creates k8s cronjob for scheduling hapi updates to DB

### Steps to test

1.
1.
1.

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
