### PR TITLE
skip persisting empty bpjson response

### DIFF
--- a/services/hapi/src/libs/sync-bps.js
+++ b/services/hapi/src/libs/sync-bps.js
@@ -25,7 +25,7 @@ const getBlockProducersData = async () => {
       {
         owner: producer.owner,
         system: { ...producer },
-        bpJson: {},
+        bpJson: {}
       }
     ]
   }, [])

--- a/services/hapi/src/libs/sync-bps.js
+++ b/services/hapi/src/libs/sync-bps.js
@@ -25,7 +25,7 @@ const getBlockProducersData = async () => {
       {
         owner: producer.owner,
         system: { ...producer },
-        bpJson: {}
+        bpJson: {},
       }
     ]
   }, [])
@@ -54,7 +54,7 @@ const getBlockProducersData = async () => {
         url: urls[i],
         method: 'get',
         json: true,
-        timeout: 5000
+        timeout: 10000
       })
       console.log('result bp', i, bp['producer_account_name'])
       try {
@@ -91,8 +91,13 @@ const updateBlockProducersData = async () => {
     const bpData = {
       owner,
       system,
-      bpjson
+      bpjson 
     }
+
+    if(!Object.keys(bpjson).length) {
+      console.log("skipping blank result for " + owner)
+      return
+    } 
 
     try {
       const result = await db.producers.save(bpData)


### PR DESCRIPTION
# GH issue 
Some BPs show they have no bp.json when they actually do #429

This change skips saving empty `bp.json` files  