### PR TITLE
Add content Help and About page

### DIFF
--- a/services/frontend/src/language/en.json
+++ b/services/frontend/src/language/en.json
@@ -197,5 +197,61 @@
     "labelTool": "votes for",
     "title": "Block Producer Community Ratings for",
     "proxyProfile": "Reviews on EOS proxy account"
+  },
+
+  "about": {
+    "tabTitle": "About EOS Rate",
+    "title": "EOS RATE: A RATING SYSTEM FOR THE EOS MAINNET",
+    "subtitle1": "What is the EOS Mainnet?",
+    "body1": {
+      "paragraph1": "If you belong to the EOSIO community – or have read something about the EOSIO blockchain – you might have heard of the EOS Mainnet. The EOS Mainnet is the main network of the EOSIO blockchain’s platform where transactions take place. Also, if you’re reading this, it’s highly probable that you know the terminology of blockchain.",
+      "paragraph2": "Further, EOSIO uses a native consensus mechanism known as “Delegated Proof-of-Stake” (DPoS), developed by Daniel Larimer. DPoS in EOSIO uses an election process where EOS token holders vote for the Block Producers (BPs) they think are the most qualified to be the custodians of the network. The EOS Mainnet runs with the twenty-one BPs that obtain the most votes.",
+      "paragraph3": "So, the DPoS mechanism requires these twenty-one elected nodes to produce the blocks, and, in exchange, they can receive rewards. One of the underlying opportunities of EOSIO by using DPoS is the ability to scale. Hence, DPoS allows Block Producers to reach consensus faster than traditional PoW (Proof-of-Work) or PoS (Proof-of-Stake) mechanisms. For instance, this enables EOS nodes to validate up to 4,000 transactions per second, in comparison to Ethereum that can reach 15."
+    },
+    "subtitle2": "With Great Power Comes Great Responsibility",
+    "body2": {
+      "paragraph1": "Nonetheless, people in the EOS community claim that both DPoS and the EOS Mainnet may be having some drawbacks, including more centralization in a network that’s supposed to be decentralized. For example, in one case, some accounts were frozen by BPs, which raised people’s eyebrows in the community. Also, there have been some disagreements associated with performance degradation in the network.",
+      "paragraph2": "Consequently, token holders who elect the twenty-one nodes can only trust the transparency and democracy of the EOS Mainnet. Thus, these BPs are the ones who must protect and keep the mainnet up and running in the best interests of the voting community.",
+      "paragraph3": "As of now, it’s only possible to keep track of rankings according to votes by token holders. However, the weight of token holders’ votes is determined by the number of EOS tokens they possess, meaning that token holders with more EOS can cast a more weighted vote for the BPs they want to endorse. In other words, those who have fewer EOS tokens may seem underrepresented. So, the importance of maintaining a transparent and trustworthy election process in the EOS Mainnet is what brought to life the idea of the open-source app called EOS Rate."
+    },
+    "subtitle3": "What Is EOS Rate?",
+    "body3": {
+      "paragraph1": "EOS Rate is an open-source, decentralized app (Dapp) built by a team of developers in Costa Rica. It allows EOS token holders to access a rating system and voting portal for BPs and Proxies, making it easier for the token holders to make an informed decision.",
+      "paragraph2": "Moreover, EOS Rate intends to gather global ratings to help capture collective opinion, or “wisdom of the crowd,” and measure if the voting patterns reflect voter sentiment. Then, the Dapp generates profile pages of the BPs, using a radial component called “LEAF” (Liquid EOS Attribute Factores) to help the users visually compare the most relevant qualitative attributes of BPs.",
+      "paragraph3": "So, to submit ratings, the token holders must sign in with their EOS wallet, making the voting process more secure and transparent. This means that one account can only represent one rating submission per BP. Then, the ratings are securely stored in the EOS blockchain to guarantee the immutability of the ratings.",
+      "paragraph4": "In addition, token holders can submit their rating in EOS Rate using five distinct categories:",
+      "paragraph5": "In particular, once a token holder submits his or her ratings, the total of the ratings will be displayed as radial graphs. So, the process of EOS Rate would be something like this:"
+    },
+    "categories": {
+      "transparency": {
+        "title": "Transparency",
+        "description": "Compliance with disclosure of ownership, complete bp.json, use of rewards, and financial stats."
+      },
+      "infrastructure": {
+        "title": "Infrastructure",
+        "description": "Stability and reliability of the EOS infrastructure."
+      },
+      "trustiness": {
+        "title": "Trustiness",
+        "description": "Collaboration and reputation among the EOS community."
+      },
+      "community": {
+        "title": "Community",
+        "description": "Community value creation through education and promoting talks, chats, hackathons, conferences, seminars, developer spaces, and other useful content."
+      },
+      "development": {
+        "title": "Development",
+        "description": "Technical know-how and usage of open-source software, scripts, frameworks, wallets, voting portals, metrics, etc."
+      }
+    }
+  },
+
+  "help": {
+    "tabTitle": "Help",
+    "title": "Thank you for using EOS Rate!",
+    "paragraph": "EOS Rate is still in progress. If you are experiencing any issues, please contact us using the following links:",
+    "githubEOSCR": "Github EOS Costa Rica",
+    "telegramChannel": "Telegram Channel",
+    "websiteEOSCR": "Website EOS Costa Rica"
   }
 }

--- a/services/frontend/src/language/es.json
+++ b/services/frontend/src/language/es.json
@@ -197,5 +197,61 @@
     "labelTool": "vota por",
     "title": "Calificaciones de productor de bloques EOS",
     "proxyProfile": "Reseñas sobre EOS proxy"
+  },
+
+  "about": {
+    "tabTitle": "Acerca de EOS Rate",
+    "title": "EOS RATE: UN SISTEMA DE CALIFICACIÓN PARA LA RED PRINCIPAL EOS",
+    "subtitle1": "¿Qué es la EOS Mainnet?",
+    "body1": {
+      "paragraph1": "Si pertenece a la comunidad EOSIO, o ha leído algo sobre la cadena de bloques EOSIO, es posible que haya oído hablar de EOS Mainnet. EOS Mainnet es la red principal de la plataforma EOSIO blockchain donde se realizan las transacciones. Además, si está leyendo esto, es muy probable que conozca la terminología de blockchain.",
+      "paragraph2": "Además, EOSIO utiliza un mecanismo de consenso nativo conocido como \"Prueba de participación delegada\" (DPoS por sus siglas en inglés), desarrollado por Daniel Larimer. DPoS en EOSIO utiliza un proceso de elección en el que los titulares de tokens de EOS votan por los productores de bloques (BP) que creen que son los más calificados para ser los custodios de la red. EOS Mainnet funciona con los veintiún BP que obtienen la mayor cantidad de votos.",
+      "paragraph3": "Por lo tanto, el mecanismo DPoS requiere estos veintiún nodos elegidos para producir los bloques y, a cambio, pueden recibir recompensas. Una de las oportunidades subyacentes de EOSIO al usar DPoS es la capacidad de escalar. Por lo tanto, DPoS permite a los productores de bloques llegar a un consenso más rápido que los mecanismos tradicionales de PoW (prueba de trabajo) o PoS (prueba de participación). Por ejemplo, esto permite que los nodos EOS validen hasta 4,000 transacciones por segundo, en comparación con Ethereum que puede llegar a 15."
+    },
+    "subtitle2": "Con un gran poder viene una gran responsabilidad",
+    "body2": {
+      "paragraph1": "No obstante, las personas de la comunidad EOS afirman que tanto DPoS como EOS Mainnet pueden tener algunos inconvenientes, incluida una mayor centralización en una red que se supone que está descentralizada. Por ejemplo, en un caso, algunas cuentas fueron congeladas por BP, lo que levantó las cejas de las personas en la comunidad. Además, ha habido algunos desacuerdos asociados con la degradación del rendimiento en la red.",
+      "paragraph2": "En consecuencia, los titulares de tokens que eligen los veintiún nodos solo pueden confiar en la transparencia y la democracia de EOS Mainnet. Por lo tanto, estos BP son los que deben proteger y mantener la red principal en funcionamiento en el mejor interés de la comunidad de votantes.",
+      "paragraph3": "A partir de ahora, solo es posible realizar un seguimiento de las clasificaciones según los votos de los titulares de tokens. Sin embargo, el peso de los votos de los titulares de tokens está determinado por la cantidad de tokens EOS que poseen, lo que significa que los titulares de tokens con más EOS pueden emitir un voto más ponderado para los BP que desean respaldar. En otras palabras, aquellos que tienen menos tokens EOS pueden parecer subrepresentados. Entonces, la importancia de mantener un proceso electoral transparente y confiable en EOS Mainnet es lo que dio vida a la idea de la aplicación de código abierto llamada EOS Rate."
+    },
+    "subtitle3": "¿Qué es EOS Rate?",
+    "body3": {
+      "paragraph1": "EOS Rate es una aplicación descentralizada de código abierto (Dapp por sus siglas en inglés) creada por un equipo de desarrolladores en Costa Rica. Permite a los titulares de tokens EOS acceder a un sistema de clasificación y portal de votación para BPs y Proxies, lo que facilita a los titulares de tokens tomar una decisión informada.",
+      "paragraph2": "Además, EOS Rate tiene la intención de reunir calificaciones globales para ayudar a capturar la opinión colectiva, o \"sabiduría de la multitud\", y medir si los patrones de votación reflejan el sentimiento de los votantes. Luego, el Dapp genera páginas de perfil de los BP, utilizando un componente radial llamado \"LEAF\" (Factores de atributo Liquid EOS) para ayudar a los usuarios a comparar visualmente los atributos cualitativos más relevantes de los BP.",
+      "paragraph3": "Por lo tanto, para enviar calificaciones, los titulares de tokens deben iniciar sesión con su billetera EOS, lo que hace que el proceso de votación sea más seguro y transparente. Esto significa que una cuenta solo puede representar una presentación de calificación por BP. Luego, las clasificaciones se almacenan de forma segura en la cadena de bloques EOS para garantizar la inmutabilidad de las clasificaciones.",
+      "paragraph4": "Además, los titulares de tokens pueden enviar su calificación en EOS Rate usando cinco categorías distintas:",
+      "paragraph5": "En particular, una vez que el titular de un token presenta sus calificaciones, el total de las calificaciones se mostrará como gráficos radiales. Entonces, el proceso de EOS Rate sería algo como esto:"
+    },
+    "categories": {
+      "transparency": {
+        "title": "Transparencia",
+        "description": "Cumplimiento de la divulgación de la propiedad, bp.json completo, uso de recompensas y estadísticas financieras."
+      },
+      "infrastructure": {
+        "title": "Infraestructura",
+        "description": "Estabilidad y confiabilidad de la infraestructura EOS."
+      },
+      "trustiness": {
+        "title": "Lealtad",
+        "description": "Colaboración y reputación entre la comunidad EOS."
+      },
+      "community": {
+        "title": "Comunidad",
+        "description": "Creación de valor comunitario a través de la educación y la promoción de charlas, chats, hackatones, conferencias, seminarios, espacios para desarrolladores y otro contenido útil."
+      },
+      "development": {
+        "title": "Desarrollo",
+        "description": "Conocimientos técnicos y uso de software de código abierto, scripts, marcos, billeteras, portales de votación, métricas, etc."
+      }
+    }
+  },
+
+  "help": {
+    "tabTitle": "Ayuda",
+    "title": "¡Gracias por usar EOS Rate!",
+    "paragraph": "EOS Rate aún está en progreso. Si tiene algún problema, contáctenos utilizando los siguientes enlaces:",
+    "githubEOSCR": "Github de EOS Costa Rica",
+    "telegramChannel": "Canal de Telegram",
+    "websiteEOSCR": "Website de EOS Costa Rica"
   }
 }

--- a/services/frontend/src/routes/about/index.js
+++ b/services/frontend/src/routes/about/index.js
@@ -1,27 +1,161 @@
 import React from 'react'
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/styles'
+import { useTranslation } from 'react-i18next'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box'
+import classNames from 'classnames'
+
+import TitlePage from 'components/title-page'
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    padding: theme.spacing(3)
+  wrapperContainers: {
+    color: '#433F5B',
+    padding: theme.spacing(6, 2),
+    '& h6': {
+      marginBottom: theme.spacing(1)
+    },
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(6, 4)
+    }
+  },
+  firstContainer: {
+    backgroundColor: theme.palette.surface.main,
+    '& h5': {
+      fontSize: theme.typography.h4.fontSize,
+      marginBottom: 12.5
+    }
+  },
+  middleContainer: {
+    backgroundColor: theme.palette.surface.main,
+    '& img': {
+      width: '100%'
+    }
+  },
+  lastContainer: {
+    backgroundColor: '#f5f5f5'
   }
 }))
 
 const About = () => {
   const classes = useStyles()
+  const { t } = useTranslation('about')
 
   return (
-    <div className={classes.root}>
-      <Typography
-        variant='h5'
-      >
-        ABOUT
-      </Typography>
-    </div>
+    <Box>
+      <TitlePage title={t('tabTitle')} />
+      <Grid container direction='column'>
+        <Grid item xs>
+          <Grid
+            container
+            direction='column'
+            className={classNames(
+              classes.wrapperContainers,
+              classes.firstContainer
+            )}
+          >
+            <Typography variant='h5'>{t('title')}</Typography>
+            <Typography variant='h6'>{t('subtitle1')}</Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body1.paragraph1')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body1.paragraph2')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body1.paragraph3')}
+            </Typography>
+          </Grid>
+        </Grid>
+
+        <Grid item xs>
+          <Grid
+            container
+            direction='column'
+            className={classNames(
+              classes.wrapperContainers,
+              classes.lastContainer
+            )}
+          >
+            <Typography variant='h6'>{t('subtitle2')}</Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body2.paragraph1')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body2.paragraph2')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body2.paragraph3')}
+            </Typography>
+          </Grid>
+        </Grid>
+
+        <Grid item xs>
+          <Grid
+            container
+            direction='column'
+            className={classNames(
+              classes.wrapperContainers,
+              classes.middleContainer
+            )}
+          >
+            <Typography variant='h6'>{t('subtitle3')}</Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body3.paragraph1')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body3.paragraph2')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body3.paragraph3')}
+            </Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body3.paragraph4')}
+            </Typography>
+            <ul>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <strong>{`${t('categories.transparency.title')}: `}</strong>
+                  {t('categories.transparency.description')}
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <strong>{`${t('categories.infrastructure.title')}: `}</strong>
+                  {t('categories.infrastructure.description')}
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <strong>{`${t('categories.trustiness.title')}: `}</strong>
+                  {t('categories.trustiness.description')}
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <strong>{`${t('categories.community.title')}: `}</strong>
+                  {t('categories.community.description')}
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <strong>{`${t('categories.development.title')}: `}</strong>
+                  {t('categories.development.description')}
+                </Typography>
+              </li>
+            </ul>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('body3.paragraph5')}
+            </Typography>
+            <img
+              src='https://eoscostarica.io/wp-content/uploads/2020/04/20200422_Infographic_EOS_Rate-Mod-Hermes-1-scaled.jpg'
+              alt='eosrate-flow'
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
   )
 }
-
-About.propTypes = {}
 
 export default About

--- a/services/frontend/src/routes/help/index.js
+++ b/services/frontend/src/routes/help/index.js
@@ -1,27 +1,94 @@
 import React from 'react'
 import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/styles'
+import { useTranslation } from 'react-i18next'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box'
+import classNames from 'classnames'
+import Link from '@material-ui/core/Link'
+
+import TitlePage from 'components/title-page'
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    padding: theme.spacing(3)
+  wrapperContainers: {
+    color: '#433F5B',
+    padding: theme.spacing(6, 2),
+    '& h6': {
+      marginBottom: theme.spacing(1)
+    },
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(6, 4)
+    }
+  },
+  firstContainer: {
+    '& h5': {
+      fontSize: theme.typography.h4.fontSize,
+      marginBottom: 12.5
+    }
   }
 }))
 
 const Help = () => {
   const classes = useStyles()
+  const { t } = useTranslation('help')
 
   return (
-    <div className={classes.root}>
-      <Typography
-        variant='h5'
-      >
-        HELP
-      </Typography>
-    </div>
+    <Box>
+      <TitlePage title={t('tabTitle')} />
+      <Grid container direction='column'>
+        <Grid item xs>
+          <Grid
+            container
+            direction='column'
+            className={classNames(
+              classes.wrapperContainers,
+              classes.firstContainer
+            )}
+          >
+            <Typography variant='h5'>{t('title')}</Typography>
+            <Typography variant='body2' align='justify' paragraph>
+              {t('paragraph')}
+            </Typography>
+            <ul>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <Link
+                    href='https://github.com/eoscostarica'
+                    target='_blank'
+                    rel='noreferrer'
+                  >
+                    {t('githubEOSCR')}
+                  </Link>
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <Link
+                    href='https://web.telegram.org/#/eoscr'
+                    target='_blank'
+                    rel='noreferrer'
+                  >
+                    {t('telegramChannel')}
+                  </Link>
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' align='justify' paragraph>
+                  <Link
+                    href='https://eoscostarica.io/'
+                    target='_blank'
+                    rel='noreferrer'
+                  >
+                    {t('websiteEOSCR')}
+                  </Link>
+                </Typography>
+              </li>
+            </ul>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
   )
 }
-
-Help.propTypes = {}
 
 export default Help

--- a/services/frontend/src/routes/home/cover.js
+++ b/services/frontend/src/routes/home/cover.js
@@ -54,39 +54,19 @@ const HomeCover = ({ classes, blockProducer }) => {
         <Typography variant='h6' className={classes.subtitle}>
           {t('cover.paragraph.subtitle1')}
         </Typography>
-        <Typography
-          variant='body2'
-          className={classes.paragraph}
-          align='justify'
-          paragraph
-        >
+        <Typography variant='body2' align='justify' paragraph>
           {t('cover.paragraph.text1')}
         </Typography>
-        <Typography
-          variant='body2'
-          className={classes.paragraph}
-          align='justify'
-          paragraph
-        >
+        <Typography variant='body2' align='justify' paragraph>
           {t('cover.paragraph.text2')}
         </Typography>
         <Typography variant='h6' className={classes.subtitle}>
           {t('cover.paragraph.subtitle2')}
         </Typography>
-        <Typography
-          variant='body2'
-          className={classes.paragraph}
-          align='justify'
-          paragraph
-        >
+        <Typography variant='body2' align='justify' paragraph>
           {t('cover.paragraph.text3')}
         </Typography>
-        <Typography
-          variant='body2'
-          className={classes.paragraph}
-          align='justify'
-          paragraph
-        >
+        <Typography variant='body2' align='justify' paragraph>
           {t('cover.paragraph.text4')}
         </Typography>
         <div className={classes.ctaContainer}>
@@ -114,10 +94,6 @@ const HomeCover = ({ classes, blockProducer }) => {
           />
         </div>
       </Grid>
-
-      {/* <Grid item xs={12}>
-      <ParameterRangeSelector defaultValue={[0, 50]} />
-    </Grid> */}
     </Grid>
   )
 }


### PR DESCRIPTION
### GH Issue

#470 #471 

Add content for Help and About page

### Steps to test

1. run `make dev`
1. go to `http://localhost:3000`
1. see Help page content and About page content

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
