### PR TITLE
Docker image names not specific enough for public repository

### DIFF
--- a/utils/meta.mk
+++ b/utils/meta.mk
@@ -3,9 +3,9 @@
 VERSION ?= $(shell git rev-parse --short HEAD)
 CURRENT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
-IMAGE_NAME_WEBAPP=webapp
-IMAGE_NAME_HAPI=hapi
-IMAGE_NAME_HASURA=hasura
+IMAGE_NAME_WEBAPP=eosrate-webapp
+IMAGE_NAME_HAPI=eosrate-hapi
+IMAGE_NAME_HASURA=eosrate-hasura
 
 DOCKER_REGISTRY=eoscostarica506
 SUBDIRS = webapp hapi hasura


### PR DESCRIPTION
The docker hub repository image names did not specify they are related to eos-rate