### PR TITLE
fix(webapp): add GA and styling UI

### DIFF
--- a/webapp/src/components/InputAutocomplete/styles.js
+++ b/webapp/src/components/InputAutocomplete/styles.js
@@ -20,6 +20,7 @@ export default theme => ({
     width: '100%',
     [theme.breakpoints.up('md')]: {
       width: 344,
+      height: 58,
       backgroundColor: 'rgba(0, 0, 0, 0.50)',
       '&:hover': {
         backgroundColor: 'rgba(0, 0, 0, 0.45)'

--- a/webapp/src/config/polar-radar-config.js
+++ b/webapp/src/config/polar-radar-config.js
@@ -24,11 +24,11 @@ export const options = {
     gridLineColor: '#e5e5e5',
     lineColor: '#e5e5e5',
     categories: [
-      'community',
-      'development',
-      'infrastructure',
-      'transparency',
-      'trustiness'
+      'Community',
+      'Development',
+      'Infrastructure',
+      'Transparency',
+      'Trustiness'
     ],
     lineWidth: 3,
     startOnTick: true,
@@ -44,7 +44,7 @@ export const options = {
     gridLineWidth: 3,
     gridLineColor: '#e5e5e5',
     min: 0,
-    max: 11,
+    max: 10,
     endOnTick: false,
     tickInterval: 2,
     gridLineInterpolation: 'circle',

--- a/webapp/src/layouts/Dashboard/index.js
+++ b/webapp/src/layouts/Dashboard/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Box from '@mui/material/Box'
 import { makeStyles } from '@mui/styles'
@@ -7,6 +7,7 @@ import Sidebar from '../../components/Sidebar'
 import Header from '../../components/Header'
 import Footer from '../../components/Footer'
 import Message from '../../components/Message'
+import { InitGA, LogPageView } from '../../config/google-analitycs-module'
 
 import styles from './styles'
 
@@ -21,6 +22,11 @@ const Dashboard = ({ children, routes }) => {
     setMobileOpen(!mobileOpen)
   }
 
+  useEffect(() => {
+    InitGA()
+    LogPageView()
+  }, [])
+
   return (
     <Box className={classes.root}>
       <Box>
@@ -34,7 +40,7 @@ const Dashboard = ({ children, routes }) => {
       </Box>
       <Box className={classes.mainContent}>
         <Header onDrawerToggle={handleDrawerToggle} />
-        <Box className={classes.childContent}>
+        <Box className={classes.childContent} id='childContent'>
           {children}
           <Footer />
         </Box>

--- a/webapp/src/routes/BlockProducers/index.js
+++ b/webapp/src/routes/BlockProducers/index.js
@@ -38,7 +38,10 @@ const AllBps = () => {
   })
 
   const loadMore = () => setCurrentlyVisible(currentlyVisible + 12)
-  // const goToTop = () => document.getElementById('mainContent').scrollTo(0, 0)
+
+  const goToTop = () => {
+    document.getElementById('childContent').scrollTo(0, 0)
+  }
 
   const handleOnFliterChange = async filter => {
     await setProducers(currentlyVisible, filter)
@@ -57,7 +60,7 @@ const AllBps = () => {
   }
 
   const handleOpenDesktopVotingTool = () => {
-    // goToTop()
+    goToTop()
     !state.compareBPToolVisible && setCompareBPTool(true)
   }
 

--- a/webapp/src/routes/BlockProducers/styles.js
+++ b/webapp/src/routes/BlockProducers/styles.js
@@ -35,11 +35,8 @@ export default theme => ({
     [theme.breakpoints.up('sm')]: {
       flexBasis: '50%'
     },
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('mdd')]: {
       flexBasis: '33.33%'
-    },
-    [theme.breakpoints.up('lg')]: {
-      flexBasis: '20%'
     }
   },
   compareTool: {

--- a/webapp/src/routes/Proxies/index.js
+++ b/webapp/src/routes/Proxies/index.js
@@ -30,8 +30,9 @@ const AllProxies = ({ ual = {} }) => {
     txSuccess: false
   })
 
-  const loadMore = () => setCurrentlyVisible(currentlyVisible + 12)
-  // const goToTop = () => document.getElementById('mainContent').scrollTo(0, 0)
+  const loadMore = () => {
+    setCurrentlyVisible(currentlyVisible + 12)
+  }
 
   const handleToggleCompareTool = () => {
     setCompareProxyTool(!state.compareProxyToolVisible)

--- a/webapp/src/routes/Proxies/styles.js
+++ b/webapp/src/routes/Proxies/styles.js
@@ -34,11 +34,8 @@ export default theme => ({
     [theme.breakpoints.up('sm')]: {
       flexBasis: '50%'
     },
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('mdd')]: {
       flexBasis: '33.33%'
-    },
-    [theme.breakpoints.up('lg')]: {
-      flexBasis: '20%'
     }
   },
   compareTool: {

--- a/webapp/src/theme/breakpoints.js
+++ b/webapp/src/theme/breakpoints.js
@@ -3,6 +3,7 @@ const breakpoints = {
     xs: 0,
     sm: 600,
     md: 1024,
+    mdd: 1110,
     lg: 1440,
     xl: 1920
   }

--- a/webapp/src/utils/get-bp-radar-data.js
+++ b/webapp/src/utils/get-bp-radar-data.js
@@ -4,17 +4,9 @@ export default ({ name, parameters }) => {
   const { r, g, b } = getRgbColorsFromHex(name)
 
   return {
-    // label: name,
     name,
     type: 'area',
-    // lineTension: 0.3,
-    // borderJoinStyle: 'round',
-    // backgroundColor: `rgba(${r}, ${g}, ${b}, .6)`,
-    // borderColor: `rgba(${r}, ${g}, ${b}, .6)`,
     color: `rgba(${r}, ${g}, ${b}, .6)`,
-    // pointBorderColor: '#fff',
-    // pointHoverBackgroundColor: '#fff',
-    // pointHoverBorderColor: `rgba(${r}, ${g}, ${b}, 1)`,
     data: Object.values(parameters)
   }
 }

--- a/webapp/src/utils/modeled-bp-data.js
+++ b/webapp/src/utils/modeled-bp-data.js
@@ -3,6 +3,16 @@ import _get from 'lodash.get'
 import getBPRadarData from './get-bp-radar-data'
 import calculateEosFromVotes from './convert-votes-to-eos-votes'
 
+const formatDecimal = number => {
+  if (!number) return 0
+
+  if (number % 1 !== 0) {
+    return parseFloat(number.toFixed(1))
+  }
+
+  return number
+}
+
 export default ({
   community,
   trustiness,
@@ -12,11 +22,11 @@ export default ({
   ...bp
 }) => {
   const parameters = {
-    community: community || 0,
-    development: development || 0,
-    infrastructure: infrastructure || 0,
-    transparency: transparency || 0,
-    trustiness: trustiness || 0
+    community: formatDecimal(community),
+    trustiness: formatDecimal(trustiness),
+    development: formatDecimal(development),
+    transparency: formatDecimal(transparency),
+    infrastructure: formatDecimal(infrastructure)
   }
   const votesInEos = calculateEosFromVotes(_get(bp, 'system.total_votes', 0))
   return {


### PR DESCRIPTION
### Add Google Analitycs

- Add logic for 'go to top' button
- Add google analitycs
- Format average number to one decimal (example: `Transparency: 6.5`) 
- Add labels in Polar Graph
- Add mini margin to inputSearch
- Add new breakpoint in order to hadler 1110 px resolution

### Steps to test

1. run `make run`
1. go to `localhost:3000`
1. test the webapp

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
