### PR TITLE
fix(webapp): Add styling to compare tool for lg screens

### DIFF
--- a/webapp/src/components/CompareTool/CompareGraphView.js
+++ b/webapp/src/components/CompareTool/CompareGraphView.js
@@ -116,19 +116,20 @@ const CompareGraphView = ({
   return (
     <Box className={classes.compareGraphView}>
       <Box className={classes.headerVotingCompare}>
+        <Box />
         <Box className={classes.modalHeader}>
           <Typography variant='h6' className={classes.marginRightElem}>
             {selected.length > 0
               ? `${t('voteToolTitle')} (${selected.length} ${t('chosen')})`
               : `${t('voteToolTitle')} (${t('noBPSelected')})`}
           </Typography>
-          <Box className={classes.boxCloseIcon}>
-            <CloseIcon style={{ cursor: 'pointer' }} onClick={handleOnClose} />
-          </Box>
+          <Typography variant='body1' style={{ display: 'flex' }}>
+            {t('voteToolDescription')}
+          </Typography>
         </Box>
-        <Typography variant='body1' style={{ display: 'flex' }}>
-          {t('voteToolDescription')}
-        </Typography>
+        <Box className={classes.boxCloseIcon}>
+          <CloseIcon style={{ cursor: 'pointer' }} onClick={handleOnClose} />
+        </Box>
       </Box>
       <Box className={classes.wrapperDesktop}>
         <Box className={classes.bodyModalView}>

--- a/webapp/src/components/CompareTool/CompareSliderView.js
+++ b/webapp/src/components/CompareTool/CompareSliderView.js
@@ -27,13 +27,14 @@ const CompareSliderView = ({
   return (
     <Box className={clsx(classes.compareSliderView, className)}>
       <Box className={classes.headerVotingCompare}>
+        <Box />
         <Box className={classes.modalHeader}>
           <Typography variant='h6' className={classes.marginRightElem}>
             {isProxy ? optionalLabel : t('compareToolTitle')}
           </Typography>
-          <Box className={classes.boxCloseIcon}>
-            <CloseIcon style={{ cursor: 'pointer' }} onClick={handleOnClose} />
-          </Box>
+        </Box>
+        <Box className={classes.boxCloseIcon}>
+          <CloseIcon style={{ cursor: 'pointer' }} onClick={handleOnClose} />
         </Box>
       </Box>
 

--- a/webapp/src/components/CompareTool/styles.js
+++ b/webapp/src/components/CompareTool/styles.js
@@ -8,17 +8,22 @@ export default theme => ({
     overflow: 'hidden'
   },
   compareSliderView: {
-    width: '100%'
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column'
   },
   boxSliderView: {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    alignItems: 'center'
   },
   sliderBody: {
     display: 'flex',
+    width: '100%',
     flexDirection: 'column',
     alignItems: 'center'
   },
@@ -29,6 +34,7 @@ export default theme => ({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     overflow: 'hidden',
+    alignItems: 'center',
     [theme.breakpoints.up('sm')]: {
       height: '100%'
     }
@@ -41,7 +47,10 @@ export default theme => ({
     [theme.breakpoints.up('sm')]: {
       paddingTop: theme.spacing(1),
       flexDirection: 'row',
-      overflow: 'hidden'
+      overflow: 'hidden',
+      height: '100%',
+      width: '100%',
+      maxWidth: 1024
     }
   },
   btnClear: {
@@ -66,9 +75,12 @@ export default theme => ({
   },
   modalHeader: {
     display: 'flex',
-    justifyContent: 'space-between',
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(2)
+    flexDirection: 'column',
+    width: '100%',
+    maxWidth: 1024,
+    [theme.breakpoints.up('mdg')]: {
+      marginLeft: 24
+    }
   },
   switchBox: {
     textAlign: 'center',
@@ -106,6 +118,8 @@ export default theme => ({
     textAlign: 'center'
   },
   slider: {
+    width: '100%',
+    maxWidth: 1024,
     display: 'flex',
     flexWrap: 'nowrap',
     overflowX: 'auto',
@@ -173,7 +187,7 @@ export default theme => ({
   headerVotingCompare: {
     display: 'flex',
     justifyContent: 'space-between',
-    flexDirection: 'column'
+    width: '100%'
   },
   marginRightElem: {
     marginRight: 10
@@ -216,16 +230,17 @@ export default theme => ({
     backgroundColor: theme.palette.surface.main,
     padding: theme.spacing(2, 0),
     [theme.breakpoints.up('sm')]: {
-      width: 300,
+      width: '100%',
+      maxWidth: 1024,
       position: 'initial',
-      justifyContent: 'center'
+      justifyContent: 'flex-start'
     }
   },
   boxCloseIcon: {
     justifyContent: 'flex-end',
     display: 'flex',
-    alignItems: 'center',
-    height: '100%'
+    height: '100%',
+    alignItems: 'flex-start'
   },
   btnRateProxies: {
     backgroundColor: theme.palette.secondary.main,
@@ -273,10 +288,12 @@ export default theme => ({
   },
   btnBox: {
     width: '100%',
+    maxWidth: 1024,
     display: 'flex',
     justifyContent: 'space-between',
     [theme.breakpoints.up('sm')]: {
-      justifyContent: 'flex-end'
+      justifyContent: 'flex-end',
+      marginTop: theme.spacing(2)
     }
   },
   alert: {

--- a/webapp/src/theme/breakpoints.js
+++ b/webapp/src/theme/breakpoints.js
@@ -4,6 +4,7 @@ const breakpoints = {
     sm: 600,
     md: 1024,
     mdd: 1110,
+    mdg: 1115,
     lg: 1440,
     xl: 1920
   }


### PR DESCRIPTION
###  Add styling to compare tool for lg screens

### Steps to test

1. run `make run`
1. go to localhost:3000
1. test selecting some BPs and open compare tool

### Checklist
- [ ] I have added/updated tests to cover these changes.
- [ ] The branch name, commit history and PR title follow [conventions](https://developers.eoscostarica.io/docs/open-source-guidelines#pull-request-general-guidelines).
- [ ] I have taken into consideration any impact to site performance.
