### PR TITLE
devops(k8s): use latest version tags

### DIFF
--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         spec:
           containers:
             - name: hapi-cronjob
-              image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HAPI}:${VERSION}
+              image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HAPI}:latest
               args:
                 - /bin/sh
                 - -c

--- a/kubernetes/hapi-deployment.yaml
+++ b/kubernetes/hapi-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: hapi
     spec:
       containers:
-      - image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HAPI}:${VERSION}
+      - image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HAPI}:latest
         imagePullPolicy: "Always"
         name: eosrate-hapi
         envFrom:

--- a/kubernetes/hasura-deployment.yaml
+++ b/kubernetes/hasura-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         envFrom:
         - configMapRef:
             name: hasura-config
-        image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HASURA}:${VERSION}
+        image: ${DOCKER_REGISTRY}/${IMAGE_NAME_HASURA}:latest
         imagePullPolicy: "Always"
         name: eosrate-hasura
         ports:

--- a/kubernetes/webapp-deployment.yaml
+++ b/kubernetes/webapp-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: webapp
     spec:
       containers:
-      - image: ${DOCKER_REGISTRY}/${IMAGE_NAME_WEBAPP}:${VERSION}
+      - image: ${DOCKER_REGISTRY}/${IMAGE_NAME_WEBAPP}:latest
         imagePullPolicy: "Always"
         name: eosrate-webapp
         env:


### PR DESCRIPTION
### GH Issue

New replica set is created for each version , perhaps using latest is a better approach?